### PR TITLE
Mobile Responsive: Headers and Vault Page

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -25,15 +25,22 @@ const Header = ({ links }) => {
     <AppBar className={`${classes.appBar} ${classes.dark}`}>
       <Toolbar className={classes.container}>
         <Button className={classes.title}>
-          <img alt="BIFI" src={require(`images/BIFI.svg`)} height="40px" className={classes.logo} />
-          <a href="https://beefy.finance">beefy.finance</a>
+          <Hidden xsDown>
+            <img alt="BIFI" src={require(`images/BIFI.svg`)} height={"40px"} className={classes.logo} />
+            <a href="https://beefy.finance">beefy.finance</a>
+          </Hidden>
+          <Hidden smUp>
+            <img alt="BIFI" src={require(`images/BIFI.svg`)} height={"35px"} className={classes.logo} />
+          </Hidden>
         </Button>
 
         <span>
           {renderLink('gov', 'gov', 'landmark', classes)}
           {renderLink('vote', 'vote', 'vote-yea', classes)}
-          {renderLink('dashboard', 'stats', 'chart-bar', classes)}
-          {renderLink('docs', 'docs', 'book', classes)}
+          <Hidden xsDown>
+            {renderLink('dashboard', 'stats', 'chart-bar', classes)}
+            {renderLink('docs', 'docs', 'book', classes)}
+          </Hidden>
           {renderLink('buy', 'buy', 'dollar-sign', classes)}
         </span>
 
@@ -66,6 +73,13 @@ const Header = ({ links }) => {
             <Close />
           </IconButton>
           <div className={classes.appResponsive}>{links}</div>
+          <div style={{ textAlign: "center" }}>
+            {renderLinkSidebar('gov', 'gov', 'landmark', classes)}
+            {renderLinkSidebar('vote', 'vote', 'vote-yea', classes)}
+            {renderLinkSidebar('dashboard', 'stats', 'chart-bar', classes)}
+            {renderLinkSidebar('docs', 'docs', 'book', classes)}
+            {renderLinkSidebar('buy', 'buy', 'dollar-sign', classes)}
+          </div>
         </Drawer>
       </Hidden>
     </AppBar>
@@ -73,32 +87,26 @@ const Header = ({ links }) => {
 };
 
 const renderLink = (name, label, icon, classes) => {
-  
-  if (name === "buy") {
-    return (
-      <a
-        href="https://streetswap.vip/#/swap?inputCurrency=BNB&outputCurrency=0xca3f508b8e4dd382ee878a314789373d80a5190a"
-        target="_blank"
-        rel="noopener noreferrer"
-        className={classes.link}
-      >
-      <i className={`fas fa-${icon} ${classes.icon}`} />
-      <span>{label}</span>
-    </a>
-    );
-  }
-
   return (
-    <a
-      href={`https://${name}.beefy.finance`}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={classes.link}
-    >
+    <a href={getLinkUrl(name)} target="_blank" rel="noopener noreferrer" className={classes.link} style={{ marginLeft: "5px", marginRight: "5px" }}>
       <i className={`fas fa-${icon} ${classes.icon}`} />
       <span>{label}</span>
     </a>
   );
 };
+
+const renderLinkSidebar = (name, label, icon, classes) => {
+  return (
+    <div style={{ width: "100%", paddingTop: "10px" }}>
+      {renderLink(name, label, icon, classes)}
+    </div>
+  );
+};
+
+const getLinkUrl = (name) => {
+  return name === "buy" 
+    ? "https://streetswap.vip/#/swap?inputCurrency=BNB&outputCurrency=0xca3f508b8e4dd382ee878a314789373d80a5190a" 
+    : `https://${name}.beefy.finance`
+}
 
 export default Header;

--- a/src/features/vault/components/PoolSummary/PoolSummary.js
+++ b/src/features/vault/components/PoolSummary/PoolSummary.js
@@ -43,10 +43,8 @@ const PoolSummary = ({ pool, toggleCard, isOpen, balanceSingle, sharesBalance, d
         />
         <Grid item md={7} xs={4}>
           <Grid item container justify="space-between">
-            <Hidden mdDown>
+            <Hidden xsDown>
               <LabeledStat value={format(balanceSingle)} label={t('Vault-Balance')} xs={5} md={3} />
-            </Hidden>
-            <Hidden smDown>
               <LabeledStat
                 value={format(
                   byDecimals(
@@ -59,26 +57,26 @@ const PoolSummary = ({ pool, toggleCard, isOpen, balanceSingle, sharesBalance, d
                 md={3}
                 align="start"
               />
+              <LabeledStat
+                value={pool.unstableApy ? '??? %' : formatApy(depositedApy, pool.defaultApy)}
+                label={t('Vault-APY')}
+                xs={5}
+                md={2}
+                align="start"
+              />
+              <LabeledStat
+                value={pool.unstableApy ? '??? %' : calcDaily(depositedApy, pool.defaultApy)}
+                label={t('Vault-APYDaily')}
+                xs={5}
+                md={2}
+              />
+              <LabeledStat
+                value={formatTvl(pool.tvl, pool.oraclePrice, pool.fallbackPrice)}
+                label={t('Vault-TVL')}
+                xs={5}
+                md={2}
+              />
             </Hidden>
-            <LabeledStat
-              value={pool.unstableApy ? '??? %' : formatApy(depositedApy, pool.defaultApy)}
-              label={t('Vault-APY')}
-              xs={5}
-              md={2}
-              align="start"
-            />
-            <LabeledStat
-              value={pool.unstableApy ? '??? %' : calcDaily(depositedApy, pool.defaultApy)}
-              label={t('Vault-APYDaily')}
-              xs={5}
-              md={2}
-            />
-            <LabeledStat
-              value={formatTvl(pool.tvl, pool.oraclePrice, pool.fallbackPrice)}
-              label={t('Vault-TVL')}
-              xs={5}
-              md={2}
-            />
           </Grid>
         </Grid>
         <SummaryActions
@@ -86,6 +84,41 @@ const PoolSummary = ({ pool, toggleCard, isOpen, balanceSingle, sharesBalance, d
           toggleCard={toggleCard}
           isOpen={isOpen}
         />
+
+        <Hidden smUp>
+          <Grid item xs={12} style={{ display: 'flex' }}>
+            <LabeledStat value={format(balanceSingle)} label={t('Vault-Balance')} xs={6} />
+            <LabeledStat
+              value={format(
+                byDecimals(
+                  sharesBalance.multipliedBy(new BigNumber(pool.pricePerFullShare)),
+                  pool.tokenDecimals
+                )
+              )}
+              label={t('Vault-Deposited')}
+              xs={6}
+              align="start"
+            />
+          </Grid>
+          <Grid item xs={12} style={{ display: 'flex' }}>
+            <LabeledStat
+              value={pool.unstableApy ? '??? %' : formatApy(depositedApy, pool.defaultApy)}
+              label={t('Vault-APY')}
+              xs={4}
+              align="start"
+            />
+            <LabeledStat
+              value={pool.unstableApy ? '??? %' : calcDaily(depositedApy, pool.defaultApy)}
+              label={t('Vault-APYDaily')}
+              xs={4}
+            />
+            <LabeledStat
+              value={formatTvl(pool.tvl, pool.oraclePrice, pool.fallbackPrice)}
+              label={t('Vault-TVL')}
+              xs={4}
+            />
+          </Grid>
+        </Hidden>
       </Grid>
     </AccordionSummary>
   );

--- a/src/features/vault/components/Pools/styles.js
+++ b/src/features/vault/components/Pools/styles.js
@@ -17,6 +17,9 @@ const styles = theme => ({
     fontSize: '14px',
     letterSpacing: '0',
     lineHeight: '8px',
+    [theme.breakpoints.down('xs')]: {
+      lineHeight: '16px',
+    },
     fontWeight: '550',
     color: '#000',
   },


### PR DESCRIPTION
Some improvements for mobile views.

Vault Details:
<img width="287" alt="Screenshot 2020-12-14 at 11 37 23 PM" src="https://user-images.githubusercontent.com/75980156/102096768-6b246400-3e68-11eb-98f6-647dec01bdf6.png">

Headers + Vault Headings:
<img width="283" alt="Screenshot 2020-12-14 at 11 37 34 PM" src="https://user-images.githubusercontent.com/75980156/102096801-74adcc00-3e68-11eb-8170-74cfcbaa6be9.png">

Headers Sidebar: (yes, the cow is slightly smaller)
<img width="285" alt="Screenshot 2020-12-14 at 11 37 42 PM" src="https://user-images.githubusercontent.com/75980156/102096817-7a0b1680-3e68-11eb-81a6-c9f1d65c2be7.png">
