### PR TITLE
Exclude duplicate contracts from TVL

### DIFF
--- a/src/features/vault/hooks/usePoolsTvl.js
+++ b/src/features/vault/hooks/usePoolsTvl.js
@@ -6,7 +6,13 @@ const usePoolsTvl = pools => {
   useEffect(() => {
     let globalTvl = 0;
 
+    const isUniqueEarnContract = ((pool, index, pools) => {
+      const earnContractAddress = pool.earnContractAddress
+      return pools.findIndex(p => p.earnContractAddress === earnContractAddress) === index
+    });
+
     pools.filter(p => p.status === 'active')
+      .filter(isUniqueEarnContract)
       .forEach(({ tvl, oraclePrice, fallbackPrice }) => {
         globalTvl += tvl * (oraclePrice || fallbackPrice);
       });


### PR DESCRIPTION
Venus BNB and WBNB are duplicated in TVL currently.
Add filter by unique `earnContractAddress`
