### PR TITLE
Fix price cache

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -6,6 +6,7 @@ import { hot, setConfig } from 'react-hot-loader';
 import store from './common/store';
 import routeConfig from './common/routeConfig';
 import history from './common/history';
+import { initializePriceCache } from './features/web3/fetchPrice'
 
 setConfig({
   logLevel: 'debug',
@@ -41,6 +42,7 @@ function renderRouteConfigV3(routes, contextPath) {
 
 function Root() {
   const children = renderRouteConfigV3(routeConfig, '/');
+  initializePriceCache()
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>{children}</ConnectedRouter>

--- a/src/features/vault/redux/fetchPoolBalances.js
+++ b/src/features/vault/redux/fetchPoolBalances.js
@@ -68,7 +68,6 @@ export function fetchPoolBalances(data) {
               },
               callbackInner => {
                 fetchPrice({
-                  oracle: pool.oracle,
                   id: pool.oracleId,
                 })
                   .then(data => {

--- a/src/features/web3/fetchPrice.js
+++ b/src/features/web3/fetchPrice.js
@@ -18,7 +18,7 @@ const WBNB = '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c';
 const BUSD = '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56';
 const WBNB_BUSD = `${WBNB}_${BUSD}`;
 
-const CACHE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+const CACHE_TIMEOUT_MS = 1 * 60 * 1000; // 1 minute(s)
 const priceCache = {
   cache: new Map(),
   lastUpdated: undefined

--- a/src/features/web3/fetchPrice.js
+++ b/src/features/web3/fetchPrice.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import BandChain from '@bandprotocol/bandchain.js';
+import { pools } from '../configure/pools'
 
 const endpoints = {
   bandchain: 'https://poa-api.bandchain.org',
@@ -18,145 +19,142 @@ const BUSD = '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56';
 const WBNB_BUSD = `${WBNB}_${BUSD}`;
 
 const CACHE_TIMEOUT = 30 * 60 * 1000;
-const cache = {};
-
-function isCached({ oracle, id }) {
-  if (`${oracle}-${id}` in cache) {
-    return cache[`${oracle}-${id}`].t + CACHE_TIMEOUT > Date.now();
-  }
-  return false;
+const priceCache = {
+  cache: new Map(),
+  lastUpdated: undefined
 }
 
-function getCachedPrice({ oracle, id }) {
-  return cache[`${oracle}-${id}`].price;
+function isCached(id) {
+  return priceCache.cache.has(id)
+  // return cache.get(id).t + CACHE_TIMEOUT > Date.now();
 }
 
-function addToCache({ oracle, id, price }) {
-  cache[`${oracle}-${id}`] = { price: price, t: Date.now() };
+function getCachedPrice(id) {
+  return priceCache.cache.get(id);
 }
 
-const fetchBand = async id => {
+// Fetch prices from different sources
+// Expected format: { id1: 100, id2: 200 }
+const fetchBand = async ids => {
   try {
     const bandchain = new BandChain(endpoints.bandchain);
-    const price = await bandchain.getReferenceData([id]);
-    return price[0].rate;
+    const response = await bandchain.getReferenceData(ids);
+    const prices = {}
+    response.forEach(price => {
+      prices[price.pair] = price.rate
+    })
+    return prices;
   } catch (err) {
     console.error(err);
-    return 0;
+    return {};
   }
 };
 
-const fetchCoingecko = async id => {
+const fetchCoingecko = async ids => {
   try {
     const response = await axios.get(endpoints.coingecko, {
-      params: { ids: id, vs_currencies: 'usd' },
+      params: { ids: ids.join(','), vs_currencies: 'usd' },
     });
-    return response.data[id].usd;
+    const prices = {}
+    for (let id in response.data) {
+      prices[id] = response.data[id].usd
+    }
+    return prices;
   } catch (err) {
     console.error(err);
-    return 0;
+    return {};
   }
 };
 
-const fetchPancake = async id => {
+const fetchPancake = async () => {
   try {
     const response = await axios.get(endpoints.pancake);
-    return response.data.prices[id];
+    return response.data.prices;
   } catch (err) {
     console.error(err);
-    return 0;
+    return {};
   }
 };
 
-const fetchThugs = async id => {
+const fetchThugs = async () => {
   try {
     const response = await axios.get(endpoints.thugs);
-    const ticker = response.data[id];
     const bnb = response.data[WBNB_BUSD]['last_price'];
+    const prices = {}
 
-    let price = 0;
+    for (let pair in response.data) {
+      const ticker = response.data[pair];
 
-    const pair = id.split('_');
-    if (pair[0] === WBNB && pair[1] === BUSD) {
-      price = bnb;
-    } else if (pair[0] === WBNB) {
-      price = bnb / ticker['last_price'];
-    } else {
-      price = bnb * ticker['last_price'];
+      let price = 0;
+      if (pair === `${WBNB}_${BUSD}`) {
+        price = bnb;
+      } else if (pair.startsWith(`${WBNB}_`)) {
+        price = bnb / ticker['last_price'];
+      } else {
+        price = bnb * ticker['last_price'];
+      }
+
+      prices[pair] = price
     }
 
-    return price;
+    return prices;
   } catch (err) {
     console.error(err);
-    return 0;
+    return {};
   }
 };
 
-const fetchLP = async (id, endpoint) => {
+const fetchLP = async (endpoint) => {
   try {
     const response = await axios.get(endpoint);
-    return response.data[id];
+    return response.data;
   } catch (err) {
     console.error(err);
-    return 0;
+    return {};
   }
 };
 
-export const fetchPrice = async ({ oracle, id }) => {
-  if (oracle === undefined) {
-    console.error('Undefined oracle');
-    return 0;
-  }
+const oracleEndpoints = {
+  'band': (ids) => fetchBand(ids),
+  'bakery-lp': () => fetchLP(endpoints.bakeryLp),
+  'coingecko': (ids) => fetchCoingecko(ids),
+  'jetfuel-lp': () => fetchLP(endpoints.jetfuelLp),
+  'narwhal-lp': () => fetchLP(endpoints.narwhalLp),
+  'pancake': () => fetchPancake(),
+  'pancake-lp': () => fetchLP(endpoints.pancakeLp),
+  'thugs': () => fetchThugs(),
+  'thugs-lp': () => fetchLP(endpoints.thugsLp)
+}
+
+export async function initializePriceCache () {
+  const oracleToIds = new Map();
+  pools.forEach(pool => {
+    if (!oracleToIds.has(pool.oracle)) {
+      oracleToIds.set(pool.oracle, []);
+    }
+    oracleToIds.get(pool.oracle).push(pool.oracleId);
+  })
+
+  const promises = [...oracleToIds.keys()].map(key => oracleEndpoints[key](oracleToIds.get(key)));
+  const currentTimestamp = new Date()
+  const results = await Promise.all(promises);
+  const allPrices = results.reduce((accPrices, curPrices) => ({...accPrices, ...curPrices}), {});
+  [...oracleToIds.values()].flat().forEach(id => priceCache.cache.set(id, allPrices[id]));
+  priceCache.lastUpdated = currentTimestamp
+}
+
+
+export const fetchPrice = async ({ id }) => {
   if (id === undefined) {
     console.error('Undefined pair');
     return 0;
   }
-
-  if (isCached({ oracle, id })) {
-    return getCachedPrice({ oracle, id });
+  
+  let counter = 0 // safe guard, though it shouldn't happen
+  while (!isCached(id) && counter < 10) {
+    console.trace(id, 'price not cached');
+    counter++;
   }
 
-  let price;
-  switch (oracle) {
-    case 'band':
-      price = await fetchBand(id);
-      break;
-
-    case 'bakery-lp':
-      price = await fetchLP(id, endpoints.bakeryLp);
-      break;
-    
-    case 'coingecko':
-      price = await fetchCoingecko(id);
-      break;
-
-    case 'jetfuel-lp':
-      price = await fetchLP(id, endpoints.jetfuelLp);
-      break;
-
-    case 'narwhal-lp':
-      price = await fetchLP(id, endpoints.narwhalLp);
-      break;
-    
-    case 'pancake':
-      price = await fetchPancake(id);
-      break;
-
-    case 'pancake-lp':
-      price = await fetchLP(id, endpoints.pancakeLp);
-      break;
-
-    case 'thugs':
-      price = await fetchThugs(id);
-      break;
-
-    case 'thugs-lp':
-      price = await fetchLP(id, endpoints.thugsLp);
-      break;
-
-    default: price = 0;
-  }
-
-  addToCache({ oracle, id, price });
-  return price;
+  return getCachedPrice(id) ? getCachedPrice(id) : 0;
 };


### PR DESCRIPTION
This PR reduces the external price requests form 90 to 9 and push forward the price cache initialization to startup.

Currently the site makes 90 requests to fetch prices, most are duplicated and can be done in 1 call. There are also optimizations to how the cache is stored.