### PR TITLE
Don't show web3modal on startup

### DIFF
--- a/src/features/home/App.js
+++ b/src/features/home/App.js
@@ -79,12 +79,6 @@ export default function App({ children }) {
   }, [setModal, t]);
 
   useEffect(() => {
-    if (web3Modal && (web3Modal.cachedProvider || window.ethereum)) {
-      connectWallet(web3Modal);
-    }
-  }, [web3Modal, connectWallet]);
-
-  useEffect(() => {
     if (
       web3 &&
       address &&


### PR DESCRIPTION
With the pool info showing without connecting to any wallet, we should remove the popup by default.