### PR TITLE
Remove fallbackPrice from calculations

### DIFF
--- a/src/features/helpers/format.js
+++ b/src/features/helpers/format.js
@@ -11,9 +11,9 @@ export const formatApy = (apy, fallbackApy) => {
   return `${num.toFixed(2)}${units[order]}%`;
 };
 
-export const formatTvl = (tvl, oraclePrice, fallbackPrice) => {
+export const formatTvl = (tvl, oraclePrice) => {
   // TODO: bignum?
-  tvl *= oraclePrice || fallbackPrice;
+  tvl *= oraclePrice;
 
   const order = Math.floor(Math.log10(tvl) / 3);
   if (order < 0) {
@@ -27,7 +27,7 @@ export const formatTvl = (tvl, oraclePrice, fallbackPrice) => {
   return prefix + num.toFixed(2) + units[order];
 };
 
-export const formatGlobalTvl = (tvl) => formatTvl(tvl, 1, 1);
+export const formatGlobalTvl = (tvl) => formatTvl(tvl, 1);
 
 export const calcDaily = (apy, fallbackApy) => {
   if (!apy) {

--- a/src/features/vault/components/PoolSummary/PoolSummary.js
+++ b/src/features/vault/components/PoolSummary/PoolSummary.js
@@ -71,7 +71,7 @@ const PoolSummary = ({ pool, toggleCard, isOpen, balanceSingle, sharesBalance, d
                 md={2}
               />
               <LabeledStat
-                value={formatTvl(pool.tvl, pool.oraclePrice, pool.fallbackPrice)}
+                value={formatTvl(pool.tvl, pool.oraclePrice)}
                 label={t('Vault-TVL')}
                 xs={5}
                 md={2}
@@ -113,7 +113,7 @@ const PoolSummary = ({ pool, toggleCard, isOpen, balanceSingle, sharesBalance, d
               xs={4}
             />
             <LabeledStat
-              value={formatTvl(pool.tvl, pool.oraclePrice, pool.fallbackPrice)}
+              value={formatTvl(pool.tvl, pool.oraclePrice)}
               label={t('Vault-TVL')}
               xs={4}
             />

--- a/src/features/vault/hooks/usePoolsTvl.js
+++ b/src/features/vault/hooks/usePoolsTvl.js
@@ -13,8 +13,8 @@ const usePoolsTvl = pools => {
 
     pools.filter(p => p.status === 'active')
       .filter(isUniqueEarnContract)
-      .forEach(({ tvl, oraclePrice, fallbackPrice }) => {
-        globalTvl += tvl * (oraclePrice || fallbackPrice);
+      .forEach(({ tvl, oraclePrice }) => {
+        globalTvl += tvl * oraclePrice;
       });
 
     setPoolsTvl(globalTvl);

--- a/src/features/vault/hooks/useSortedPools.js
+++ b/src/features/vault/hooks/useSortedPools.js
@@ -31,8 +31,8 @@ const handleApy = (pools, apys) => {
 const handleTvl = pools => {
   let newPools = [...pools];
   return newPools.sort((a, b) => {
-    const aPrice = a.oraclePrice || a.fallbackPrice;
-    const bPrice = b.oraclePrice || b.fallbackPrice;
+    const aPrice = a.oraclePrice;
+    const bPrice = b.oraclePrice;
     return b.tvl * bPrice - a.tvl * aPrice;
   });
 };


### PR DESCRIPTION
The usage of `fallbackPrice` makes the TVL jumps from $12M to $18M at the UI. Since the `fallbackPrice` is not maintained regularly, and also doesn't make the actual price calculation faster, we should remove it and keep the TVL at $0 until the actual price is calculated.