### PR TITLE
Add simple pools data validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "validate": "node ./scripts/validatePools.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/scripts/validatePools.js
+++ b/scripts/validatePools.js
@@ -1,0 +1,65 @@
+// To run: yarn validate
+
+import { pools } from '../src/features/configure/pools.js';
+
+let valid = true;
+const uniquePoolId = new Set();
+const uniqueEarnedToken = new Set();
+const uniqueEarnedTokenAddress = new Set();
+const uniqueOracleId = new Set();
+const messages = [];
+let activePools = 0;
+
+console.log(`Validating ${pools.length} pools...`);
+
+pools.forEach(pool => {
+  // Errors, should not proceed with build
+  if (uniquePoolId.has(pool.id)) {
+    messages.push(`Error: ${pool.id} : Pool id duplicated: ${pool.id}`);
+    valid = false;
+  }
+
+  if (uniqueEarnedToken.has(pool.earnedToken)) {
+    if (pool.id === 'venus-wbnb') return; // Special case, supposed to be same as venus-bnb
+    messages.push(`Error: ${pool.id} : Pool earnedToken duplicated: ${pool.earnedToken}`);
+    valid = false;
+  }
+
+  if (uniqueEarnedTokenAddress.has(pool.earnedTokenAddress)) {
+    if (pool.id === 'venus-wbnb') return; // Special case, supposed to be same as venus-bnb
+    messages.push(`Error: ${pool.id} : Pool earnedTokenAddress duplicated: ${pool.earnedTokenAddress}`);
+    valid = false;
+  }
+
+  if (pool.earnedTokenAddress !== pool.earnContractAddress) {
+    messages.push(`Error: ${pool.id} : Pool earnedTokenAddress not same as earnedContractAddress: ${pool.earnedTokenAddress}, ${pool.earnedContractAddress}`);
+    valid = false;
+  }
+
+  // Warnings, check if intended
+  if (!pool.name.toLowerCase().includes(pool.token.toLowerCase())) {
+    messages.push(`Warning: ${pool.id} : Pool name not same token type as token: ${pool.name}, ${pool.token}`);
+  }
+
+  if (uniqueOracleId.has(pool.oracleId)) {
+    messages.push(`Warning: ${pool.id} : Pool oracleId duplicated: ${pool.oracleId}`);
+  }
+
+  if (pool.status === 'active') {
+    activePools++;
+  }
+
+  uniquePoolId.add(pool.id);
+  uniqueEarnedToken.add(pool.earnedToken);
+  uniqueEarnedTokenAddress.add(pool.earnedTokenAddress);
+  uniqueOracleId.add(pool.oracleId);
+})
+
+console.log(`Active pools: ${activePools}/${pools.length}`)
+
+if (messages.length == 0) { 
+  console.log('Pools validation success.')
+} else {
+  messages.forEach(err => console.log(err))
+  console.log(`Pools validation finished with ${valid ? 'warnings.' : 'errors!'}`)
+} 


### PR DESCRIPTION
As the pools json gets larger, there might be more human-errors. We can add more conditions to make this validation stricter.

Validation with `errors` means that it might not align with our 'business as usual' (wrong contracts etc)
Validation with `warnings` means we can usually proceed without compromising user data (wrong tvl/price display etc)

Run: `yarn validate`

```
Validating 125 pools...
Active pools: 114/125
Warning: thugs-drugs-btri : Pool name not same token type as token: DRUGS BTRI, DRUGS​​​​​​
Warning: thugs-drugs-drugs : Pool oracleId duplicated: 0x339550404Ca4d831D12B1b2e4768869997390010_0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c
Warning: thugs-drugs-bhc : Pool name not same token type as token: DRUGS BHC, DRUGS​
Warning: thugs-drugs-bhc : Pool oracleId duplicated: 0x339550404Ca4d831D12B1b2e4768869997390010_0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c
Warning: thugs-drugs-jgn : Pool name not same token type as token: DRUGS JGN, DRUGS​​
Warning: thugs-drugs-jgn : Pool oracleId duplicated: 0x339550404Ca4d831D12B1b2e4768869997390010_0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c
Warning: street-drugs-bnb : Pool name not same token type as token: DRUGS-BNB LP v2, DRUGS-BNB TLP
Warning: street-thugs-bnb : Pool name not same token type as token: THUGS-BNB LP v2, THUGS-BNB TLP
Warning: street-cred-bnb : Pool name not same token type as token: CRED-BNB LP, CRED-BNB TLP
Warning: street-guns-bnb : Pool name not same token type as token: GUNS-BNB LP v2, GUNS-BNB TLP
Warning: street-busd-bnb : Pool name not same token type as token: BUSD-BNB LP v2, BUSD-BNB TLP
Warning: street-btc-bnb : Pool name not same token type as token: BTC-BNB LP v2, BTC-BNB TLP
Warning: street-eth-bnb : Pool name not same token type as token: ETH-BNB LP v2, ETH-BNB TLP
Warning: street-drugs-bnb-v1 : Pool oracleId duplicated: street-drugs-bnb
Warning: street-guns-bnb-v1 : Pool oracleId duplicated: street-guns-bnb
Warning: cake-cake : Pool oracleId duplicated: Cake
Warning: cake-twt : Pool oracleId duplicated: Cake
Warning: cake-hard : Pool oracleId duplicated: Cake
Warning: fry-burger-v1 : Pool oracleId duplicated: burger-swap
Pools validation finished with warnings.
```

It seems that there are some `thugs-drugs` pool fetching wrong price oracle, and also some inconsistent pool namings.

It's advisable that we run this before building the project.