### PR TITLE
Right align header icons

### DIFF
--- a/src/components/Header/styles.js
+++ b/src/components/Header/styles.js
@@ -231,13 +231,14 @@ const styles = theme => ({
       textDecoration: 'underline',
     },
     '& span': {
-      color: theme.palette.text.primary
-    }
+      color: theme.palette.text.primary,
+    },
   },
   icon: {
     color: theme.palette.text.primary,
     marginRight: '0.5rem',
     minWidth: '24px',
+    textAlign: 'end',
   },
   iconButton: {
     color: theme.palette.text.primary,


### PR DESCRIPTION
Small fix for icon padding following YR2150's suggestion

Desktop (after/before):
![image](https://user-images.githubusercontent.com/71946691/106352621-903d3b00-631f-11eb-8257-854a20f533af.png)

Mobile
![image](https://user-images.githubusercontent.com/71946691/106352622-94695880-631f-11eb-9d7a-2604862ff87f.png)
