### PR TITLE
Pcs bdo-bnb pool: 'Revert' back to supposed id

### DIFF
--- a/src/features/configure/pools.js
+++ b/src/features/configure/pools.js
@@ -24,7 +24,7 @@ export const pools = [
   },
 
   {
-    id: 'cake-bdo-bnb',
+    id: 'cake-bdo-bnb-cake',
     logo: 'bdollar/bdo.png',
     name: 'BDO-BNB LP',
     token: 'BDO-BNB LP',


### PR DESCRIPTION
Seems like the id got changed during code merge. Refer to: https://github.com/beefyfinance/beefy-app/pull/92

It's currently causing UI issues to the vault with the same name. Here's to change it back to what was in the previous PR.