### PR TITLE
Scroll loading of pools

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^17.0.0",
     "react-hot-loader": "^4.13.0",
     "react-i18next": "^11.7.3",
+    "react-infinite-scroll-component": "^6.0.0",
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",

--- a/src/features/vault/components/VisiblePools/VisiblePools.js
+++ b/src/features/vault/components/VisiblePools/VisiblePools.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import InfiniteScroll from 'react-infinite-scroll-component';
 import { useTranslation } from 'react-i18next';
 import { makeStyles } from '@material-ui/core/styles';
 import styles from './styles';
@@ -9,6 +10,7 @@ import usePoolsByPlatform from '../../hooks/usePoolsByPlatform';
 import usePoolsByVaultType from '../../hooks/usePoolsByVaultType';
 import usePoolsByAsset from '../../hooks/usePoolsByAsset';
 import useSortedPools from '../../hooks/useSortedPools';
+import useVisiblePools from '../../hooks/useVisiblePools';
 
 import Pool from '../Pool/Pool';
 import Filters from '../Filters/Filters';
@@ -24,6 +26,7 @@ const VisiblePools = ({ pools, tokens, apys }) => {
   const { poolsByVaultType, vaultType, setVaultType } = usePoolsByVaultType(poolsByPlatform);
   const { poolsByAsset, asset, setAsset } = usePoolsByAsset(poolsByVaultType);
   const { sortedPools, order, setOrder } = useSortedPools(poolsByAsset, apys);
+  const { visiblePools, fetchVisiblePools } = useVisiblePools(sortedPools, 10);
 
   return (
     <>
@@ -39,10 +42,13 @@ const VisiblePools = ({ pools, tokens, apys }) => {
         setAsset={setAsset}
         setOrder={setOrder}
       />
-      {sortedPools.map((pool, index) => (
-        <Pool pool={pool} index={index} tokens={tokens} apy={apys[pool.id] || 0} key={pool.id} />
-      ))}
-      
+      <div className={classes.scroller}>
+        <InfiniteScroll dataLength={visiblePools.length} hasMore={true} next={fetchVisiblePools}>
+          {visiblePools.map((pool, index) => (
+            <Pool pool={pool} index={index} tokens={tokens} apy={apys[pool.id] || 0} key={pool.id} />
+          ))}
+        </InfiniteScroll>
+      </div>
       {!sortedPools.length && <h3 className={classes.subtitle}>{t('No-Results')}</h3>}
     </>
   );

--- a/src/features/vault/components/VisiblePools/styles.js
+++ b/src/features/vault/components/VisiblePools/styles.js
@@ -1,4 +1,7 @@
 const styles = theme => ({
+  scroller: {
+    width: '100%',
+  },
   subtitle: {
     fontSize: '20px',
     letterSpacing: '0',

--- a/src/features/vault/hooks/useVisiblePools.js
+++ b/src/features/vault/hooks/useVisiblePools.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+const useVisiblePools = (pools, chunk) => {
+  const [ visiblePools, setVisiblePools ] = useState([]);
+
+  useEffect(() => {
+    setVisiblePools(pools.slice(0, chunk));
+  }, [pools, chunk]);
+
+  const fetchVisiblePools = () => {
+    const poolCount    = pools.length;
+    const visibleCount = visiblePools.length;
+
+    if(visibleCount >= poolCount) return;
+
+    // Concat visible pools with new chunk
+    const newPools = pools.slice(visibleCount, visibleCount + chunk);
+    setVisiblePools(visiblePools.concat(newPools));
+  };
+
+  return { visiblePools, fetchVisiblePools };
+};
+
+export default useVisiblePools;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11116,6 +11116,13 @@ react-i18next@^11.7.3:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
+react-infinite-scroll-component@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-6.0.0.tgz#b5834b81dad51c764e5d217e1007b14bed0ed5e7"
+  integrity sha512-GK/amOgk4J/MLw8Kpp8K6MdDdX5QLJheVSSnhI6c2b6gvMwziCE2m1GDVrMyAyP7gDjgA0YH7pxdIoQya842LQ==
+  dependencies:
+    throttle-debounce "^2.1.0"
+
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -12862,6 +12869,11 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+
+throttle-debounce@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
+  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
Load pools in chunks of 10 when scrolling.

Doesn't entirely fix #140 as the DOM can still grow very large _if_ you scroll to the bottom with no filters, but speeds up the initial load.

Full windowing of the pools is a bit of a pain because of the dynamic pool height.