### PR TITLE
Fix scroll jumping to top on pool update

### DIFF
--- a/src/features/vault/hooks/useVisiblePools.js
+++ b/src/features/vault/hooks/useVisiblePools.js
@@ -4,7 +4,12 @@ const useVisiblePools = (pools, chunk) => {
   const [ visiblePools, setVisiblePools ] = useState([]);
 
   useEffect(() => {
-    setVisiblePools(pools.slice(0, chunk));
+    // Attempt to load as many pools as there were already loaded
+    // this should stop the window jumping to the top when pools
+    // are updated.
+    setVisiblePools((previousVisiblePools) => (
+      pools.slice(0, Math.max(previousVisiblePools.length, chunk))
+    ));
   }, [pools, chunk]);
 
   const fetchVisiblePools = () => {


### PR DESCRIPTION
Fixes #147

@roman-monk this fixes it for me, can you confirm?

TL;DR When pools are updated it'll try to load the same number of pools as the previously loaded pool list, or `chunk` (10). 
Shouldn't affect filter changes as you have to scroll to the top to apply filters anyway.