### PR TITLE
(WIP) use chainId instead of networkId to track current network

### DIFF
--- a/src/features/home/App.js
+++ b/src/features/home/App.js
@@ -31,8 +31,6 @@ export default function App({ children }) {
     web3,
     address,
     networkId,
-    chainId,
-    chainId2,
     connected,
     connectWalletPending,
   } = useConnectWallet();
@@ -52,17 +50,17 @@ export default function App({ children }) {
     }
   }, [web3Modal, connectWallet]);
 
-  // useEffect(() => {
-  //   if (
-  //     web3 &&
-  //     address &&
-  //     !connectWalletPending &&
-  //     networkId &&
-  //     Boolean(networkId !== Number(process.env.REACT_APP_NETWORK_ID))
-  //   ) {
-  //     alert(t('Network-Error'));
-  //   }
-  // }, [web3, address, networkId, connectWalletPending, t]);
+  useEffect(() => {
+    if (
+      web3 &&
+      address &&
+      !connectWalletPending &&
+      networkId &&
+      Boolean(networkId !== Number(process.env.REACT_APP_NETWORK_ID))
+    ) {
+      alert(t('Network-Error'));
+    }
+  }, [web3, address, networkId, connectWalletPending, t]);
 
   return (
     <StylesProvider injectFirst>
@@ -90,9 +88,7 @@ export default function App({ children }) {
               />
               <div className={classes.container}>
                 <div className={classes.children}>
-                  <h1>{networkId}</h1>
-                  <h1>{chainId}</h1>
-                  <h1>{chainId2}</h1>
+                  {Boolean(networkId === Number(process.env.REACT_APP_NETWORK_ID)) && children}
                   <Notifier />
                 </div>
               </div>

--- a/src/features/home/App.js
+++ b/src/features/home/App.js
@@ -31,6 +31,8 @@ export default function App({ children }) {
     web3,
     address,
     networkId,
+    chainId,
+    chainId2,
     connected,
     connectWalletPending,
   } = useConnectWallet();
@@ -50,17 +52,17 @@ export default function App({ children }) {
     }
   }, [web3Modal, connectWallet]);
 
-  useEffect(() => {
-    if (
-      web3 &&
-      address &&
-      !connectWalletPending &&
-      networkId &&
-      Boolean(networkId !== Number(process.env.REACT_APP_NETWORK_ID))
-    ) {
-      alert(t('Network-Error'));
-    }
-  }, [web3, address, networkId, connectWalletPending, t]);
+  // useEffect(() => {
+  //   if (
+  //     web3 &&
+  //     address &&
+  //     !connectWalletPending &&
+  //     networkId &&
+  //     Boolean(networkId !== Number(process.env.REACT_APP_NETWORK_ID))
+  //   ) {
+  //     alert(t('Network-Error'));
+  //   }
+  // }, [web3, address, networkId, connectWalletPending, t]);
 
   return (
     <StylesProvider injectFirst>
@@ -88,7 +90,9 @@ export default function App({ children }) {
               />
               <div className={classes.container}>
                 <div className={classes.children}>
-                  {Boolean(networkId === Number(process.env.REACT_APP_NETWORK_ID)) && children}
+                  <h1>{networkId}</h1>
+                  <h1>{chainId}</h1>
+                  <h1>{chainId2}</h1>
                   <Notifier />
                 </div>
               </div>

--- a/src/features/home/redux/connectWallet.js
+++ b/src/features/home/redux/connectWallet.js
@@ -55,9 +55,10 @@ export function connectWallet(web3Modal) {
       const chainId = await web3.eth.getChainId();
       const chainId2 = await web3.eth.chainId();
 
-      alert('Network', networkId, 'Chain', chainId, 'Chain B', chainId2);
-
-      dispatch({ type: HOME_CONNECT_WALLET_SUCCESS, data: { web3, address, networkId } });
+      dispatch({
+        type: HOME_CONNECT_WALLET_SUCCESS,
+        data: { web3, address, networkId, chainId, chainId2 },
+      });
     } catch (error) {
       dispatch({ type: HOME_CONNECT_WALLET_FAILURE });
     }
@@ -66,11 +67,21 @@ export function connectWallet(web3Modal) {
 
 export function useConnectWallet() {
   const dispatch = useDispatch();
-  const { web3, address, networkId, connected, connectWalletPending } = useSelector(
+  const {
+    web3,
+    address,
+    networkId,
+    chainId,
+    chainId2,
+    connected,
+    connectWalletPending,
+  } = useSelector(
     state => ({
       web3: state.home.web3,
       address: state.home.address,
       networkId: state.home.networkId,
+      chainId: state.home.chainId,
+      chainId2: state.home.chainId2,
       connected: state.home.connected,
       connectWalletPending: state.home.connectWalletPending,
     }),
@@ -78,7 +89,16 @@ export function useConnectWallet() {
   );
   const boundAction = useCallback(data => dispatch(connectWallet(data)), [dispatch]);
 
-  return { web3, address, networkId, connected, connectWalletPending, connectWallet: boundAction };
+  return {
+    web3,
+    address,
+    networkId,
+    chainId,
+    chainId2,
+    connected,
+    connectWalletPending,
+    connectWallet: boundAction,
+  };
 }
 
 export function reducer(state, action) {
@@ -95,6 +115,8 @@ export function reducer(state, action) {
         web3: action.data.web3,
         address: process.env.ACCOUNT ? process.env.ACCOUNT : action.data.address,
         networkId: action.data.networkId,
+        chainId: action.data.chainId,
+        chainId2: action.data.chainId2,
         connected: true,
         connectWalletPending: false,
       };

--- a/src/features/home/redux/connectWallet.js
+++ b/src/features/home/redux/connectWallet.js
@@ -51,7 +51,11 @@ export function connectWallet(web3Modal) {
 
       const accounts = await web3.eth.getAccounts();
       const address = accounts[0];
-      const networkId = await web3.eth.chainId();
+      const networkId = await web3.eth.net.getId();
+      const chainId = await web3.eth.getChainId();
+      const chainId2 = await web3.eth.chainId();
+
+      alert('Network', networkId, 'Chain', chainId, 'Chain B', chainId2);
 
       dispatch({ type: HOME_CONNECT_WALLET_SUCCESS, data: { web3, address, networkId } });
     } catch (error) {

--- a/src/features/home/redux/connectWallet.js
+++ b/src/features/home/redux/connectWallet.js
@@ -51,14 +51,13 @@ export function connectWallet(web3Modal) {
 
       const accounts = await web3.eth.getAccounts();
       const address = accounts[0];
-      const networkId = await web3.eth.net.getId();
-      const chainId = await web3.eth.getChainId();
-      const chainId2 = await web3.eth.chainId();
 
-      dispatch({
-        type: HOME_CONNECT_WALLET_SUCCESS,
-        data: { web3, address, networkId, chainId, chainId2 },
-      });
+      let networkId = await web3.eth.getChainId();
+      if (networkId === 86) {
+        networkId = 56;
+      }
+
+      dispatch({ type: HOME_CONNECT_WALLET_SUCCESS, data: { web3, address, networkId } });
     } catch (error) {
       dispatch({ type: HOME_CONNECT_WALLET_FAILURE });
     }
@@ -67,21 +66,11 @@ export function connectWallet(web3Modal) {
 
 export function useConnectWallet() {
   const dispatch = useDispatch();
-  const {
-    web3,
-    address,
-    networkId,
-    chainId,
-    chainId2,
-    connected,
-    connectWalletPending,
-  } = useSelector(
+  const { web3, address, networkId, connected, connectWalletPending } = useSelector(
     state => ({
       web3: state.home.web3,
       address: state.home.address,
       networkId: state.home.networkId,
-      chainId: state.home.chainId,
-      chainId2: state.home.chainId2,
       connected: state.home.connected,
       connectWalletPending: state.home.connectWalletPending,
     }),
@@ -89,16 +78,7 @@ export function useConnectWallet() {
   );
   const boundAction = useCallback(data => dispatch(connectWallet(data)), [dispatch]);
 
-  return {
-    web3,
-    address,
-    networkId,
-    chainId,
-    chainId2,
-    connected,
-    connectWalletPending,
-    connectWallet: boundAction,
-  };
+  return { web3, address, networkId, connected, connectWalletPending, connectWallet: boundAction };
 }
 
 export function reducer(state, action) {
@@ -115,8 +95,6 @@ export function reducer(state, action) {
         web3: action.data.web3,
         address: process.env.ACCOUNT ? process.env.ACCOUNT : action.data.address,
         networkId: action.data.networkId,
-        chainId: action.data.chainId,
-        chainId2: action.data.chainId2,
         connected: true,
         connectWalletPending: false,
       };

--- a/src/features/home/redux/connectWallet.js
+++ b/src/features/home/redux/connectWallet.js
@@ -51,7 +51,8 @@ export function connectWallet(web3Modal) {
 
       const accounts = await web3.eth.getAccounts();
       const address = accounts[0];
-      const networkId = await web3.eth.net.getId();
+      const networkId = await web3.eth.chainId();
+
       dispatch({ type: HOME_CONNECT_WALLET_SUCCESS, data: { web3, address, networkId } });
     } catch (error) {
       dispatch({ type: HOME_CONNECT_WALLET_FAILURE });


### PR DESCRIPTION
We're currently using networkId to track on which network we're on. Some Ethereum forks always report "1" which breaks compatibility. For this exact reason "chainId" was added (to avoid replay attacks with ETH/ETC). 

For some reason Trust Wallet breaks when using chainId at the moment.
