### PR TITLE
APY and TVL now show up without needing a wallet connection

### DIFF
--- a/src/features/vault/components/PoolSummary/PoolSummary.js
+++ b/src/features/vault/components/PoolSummary/PoolSummary.js
@@ -149,6 +149,7 @@ const PoolSummary = ({
               value={formatDecimals(deposited)}
               subvalue={depositedUsd}
               label={t('Vault-Deposited')}
+              isLoading={!fetchBalancesDone}
               xs={6}
               align="start"
             />

--- a/src/features/vault/components/Pools/Pools.js
+++ b/src/features/vault/components/Pools/Pools.js
@@ -46,17 +46,25 @@ export default function Pools() {
   }, [fetchPoolsInfo]);
 
   useEffect(() => {
-    if (address && web3) {
-      const fetch = () => {
-        fetchBalances({ address, web3, tokens });
-        fetchVaultsData({ address, web3, pools });
-        fetchApys();
-      };
-      fetch();
+    const fetch = () => {
+      fetchApys();
+    };
+    fetch();
+    const id = setInterval(fetch, FETCH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [fetchApys]);
 
-      const id = setInterval(fetch, FETCH_INTERVAL_MS);
-      return () => clearInterval(id);
-    }
+  useEffect(() => {
+    const fetch = () => {
+      if (address && web3) {
+        fetchBalances({ address, web3, tokens });
+      }
+      fetchVaultsData({ address, web3, pools });
+    };
+    fetch();
+
+    const id = setInterval(fetch, FETCH_INTERVAL_MS);
+    return () => clearInterval(id);
 
     // Adding tokens and pools to this dep list, causes an endless loop, DDoSing the api
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -81,7 +89,7 @@ export default function Pools() {
 
           <span className={classes.text}>
             {t('Vault-Deposited')}{' '}
-            {fetchVaultsDataDone ? (
+            {fetchVaultsDataDone && fetchBalancesDone ? (
               formatGlobalTvl(myTvl)
             ) : (
               <TVLLoader className={classes.titleLoader} />

--- a/src/features/web3/index.js
+++ b/src/features/web3/index.js
@@ -5,6 +5,6 @@ export { deposit } from './deposit';
 export { depositBnb } from './depositBnb';
 export { withdraw } from './withdraw';
 export { withdrawBnb } from './withdrawBnb';
-export { fetchPrice } from './fetchPrice';
+export { fetchPrice, whenPricesLoaded } from './fetchPrice';
 export { harvest } from './harvest';
 export { createWeb3Modal } from './createWeb3Modal';


### PR DESCRIPTION
The issue #158 also mentioned to "Prompt user to collect wallet upon clicking an action button", but I'd rather have this be a separate task, because I don't want too many changes in my first pull request.

This pull request also fixes a problem with incorrect TVL when price data is slow to load. Basically, `loadVaultData` needs to wait until the initial price call returned.

I'm pretty new to web3, but I looked at pancake for examples. I used `new Web3.providers.HttpProvider('https://bsc-dataseed.binance.org')` for a default provider when there is no wallet connection.