### PR TITLE
Add Beefy Rewards pool for HECO

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -50,7 +50,8 @@ const Header = ({ links, isNightMode, setNightMode }) => {
 
         <span>
           <Hidden mdDown>
-            {renderLink('barn', 'barn', 'warehouse', classes)}
+            {Number(process.env.REACT_APP_NETWORK_ID) === 56 &&
+              renderLink('barn', 'barn', 'warehouse', classes)}
             {renderLink('vote', 'vote', 'vote-yea', classes)}
             {renderLink('dashboard', t('stats'), 'chart-bar', classes)}
             {renderLink('docs', 'docs', 'book', classes)}
@@ -93,11 +94,13 @@ const Header = ({ links, isNightMode, setNightMode }) => {
           </IconButton>
           <div className={classes.appResponsive}>{links}</div>
           <div style={{ textAlign: 'center' }}>
-            {renderLinkSidebar('barn', 'barn', 'warehouse', classes)}
-            {renderLinkSidebar('vote', 'vote', 'vote-yea', classes)}
-            {renderLinkSidebar('dashboard', t('stats'), 'chart-bar', classes)}
-            {renderLinkSidebar('docs', 'docs', 'book', classes)}
-            {renderLinkSidebar('buy', t('buy'), 'dollar-sign', classes)}
+            {Number(process.env.REACT_APP_NETWORK_ID) === 56 && (
+              <LinkSidebar name="barn" label="barn" icon="warehouse" classes={classes} />
+            )}
+            <LinkSidebar name="vote" label="vote" icon="vote-yea" classes={classes} />
+            <LinkSidebar name="dashboard" label={t('stats')} icon="chart-bar" classes={classes} />
+            <LinkSidebar name="docs" label="docs" icon="book" classes={classes} />
+            <LinkSidebar name="buy" label={t('buy')} icon="dollar-sign" classes={classes} />
             <IconButton onClick={setNightMode} className={classes.icon}>
               {isNightMode ? <WbSunny /> : <NightsStay />}
             </IconButton>
@@ -131,13 +134,9 @@ const renderBoost = classes => {
   );
 };
 
-const renderLinkSidebar = (name, label, icon, classes) => {
-  return (
-    <div style={{ width: '100%', paddingTop: '10px' }}>
-      {renderLink(name, label, icon, classes)}
-    </div>
-  );
-};
+const LinkSidebar = ({ name, label, icon, classes }) => (
+  <div style={{ width: '100%', paddingTop: '10px' }}>{renderLink(name, label, icon, classes)}</div>
+);
 
 const getLinkUrl = name => {
   return name === 'buy'

--- a/src/features/configure/stake/heco_stake.js
+++ b/src/features/configure/stake/heco_stake.js
@@ -1,1 +1,35 @@
-export const hecoStakePools = [];
+import { govPoolABI } from '../abi';
+
+export const hecoStakePools = [
+  {
+    id: 'bifi-ht',
+    name: 'BIFI',
+    logo: 'single-assets/BIFI.png',
+    token: 'BIFI',
+    tokenDecimals: 18,
+    tokenAddress: '0x765277EebeCA2e31912C9946eAe1021199B39C61',
+    tokenOracle: 'tokens',
+    tokenOracleId: 'BIFI',
+    earnedToken: 'HT',
+    earnedTokenDecimals: 18,
+    earnedTokenAddress: '0x5545153CCFcA01fbd7Dd11C0b23ba694D9509A6F',
+    earnContractAddress: '0x5f7347fedfD0b374e8CE8ed19Fc839F59FB59a3B',
+    earnContractAbi: govPoolABI,
+    earnedOracle: 'tokens',
+    earnedOracleId: 'WHT',
+    partnership: false,
+    status: 'active',
+    hideCountdown: true,
+    partner: {
+      logo: 'stake/beefy/beefyfinance.png',
+      background: 'stake/beefy/background.png',
+      text:
+        "You probably already knew that Beefy is the most trusted Yield optimizer for the Binance Smart Chain. But did you know that Beefy has its own token? $BIFI has a maximum supply of 80000 tokens and there is no way to mint more. Everyone who holds our own $BIFI token can not only do cool stuff like create and vote on proposals, they also get a share of all harvests done, every hour, every day on all our +120 vaults. That's a lot of BNB that goes straight to our $BIFI holders. All you have to do is stake your $BIFI in this vault, it’s that simple, come back and harvest your BNB whenever you need it! (You can still vote on proposals even though you have staked your $BIFI here).",
+      website: 'https://app.beefy.finance',
+      social: {
+        telegram: 'http://t.me/beefyfinance',
+        twitter: 'https://twitter.com/beefyfinance',
+      },
+    },
+  },
+];


### PR DESCRIPTION
We have BIFI on HECO now: https://hecoinfo.com/address/0x765277eebeca2e31912c9946eae1021199b39c61

I deployed a BIFI rewards pool for users to earn WHT (The wrapped version of HECO's native token).

The Pool: https://hecoinfo.com/address/0x5f7347fedfd0b374e8ce8ed19fc839f59fb59a3b#code

This PR is merging the pool into the boost section for HECO.