### PR TITLE
Connect Wallet button in pool details

### DIFF
--- a/src/features/vault/components/PoolDetails/PoolDetails.js
+++ b/src/features/vault/components/PoolDetails/PoolDetails.js
@@ -6,17 +6,40 @@ import DepositSection from './DepositSection/DepositSection';
 import WithdrawSection from './WithdrawSection/WithdrawSection';
 import HarvestSection from './HarvestSection/HarvestSection';
 import { shouldHideFromHarvest } from 'features/helpers/utils';
+import { makeStyles } from '@material-ui/core/styles';
+import styles from './styles';
+import Button from 'components/CustomButtons/Button.js';
+import { useConnectWallet } from 'features/home/redux/hooks';
+import { createWeb3Modal } from 'features/web3';
+import { useTranslation } from 'react-i18next';
+
+const useStyles = makeStyles(styles);
 
 const PoolDetails = ({ pool, balanceSingle, index, sharesBalance }) => {
-  return (
-    <AccordionDetails style={{ justifyContent: 'space-between' }}>
-      <Grid container>
-        <DepositSection index={index} pool={pool} balanceSingle={balanceSingle} />
-        <WithdrawSection index={index} pool={pool} sharesBalance={sharesBalance} />
-        {shouldHideFromHarvest(pool.id) ? '' : <HarvestSection index={index} pool={pool} />}
-      </Grid>
-    </AccordionDetails>
-  );
+  const classes = useStyles();
+  const { t } = useTranslation();
+  const { connected, connectWallet } = useConnectWallet();
+
+  const handleConnectWallet = () => {
+    const web3Modal = createWeb3Modal(t);
+    connectWallet(web3Modal);
+  };
+
+  if (connected) {
+    return (
+      <AccordionDetails style={{ justifyContent: 'space-between' }}>
+        <Grid container>
+          <DepositSection index={index} pool={pool} balanceSingle={balanceSingle} />
+          <WithdrawSection index={index} pool={pool} sharesBalance={sharesBalance} />
+          {shouldHideFromHarvest(pool.id) ? '' : <HarvestSection index={index} pool={pool} />}
+        </Grid>
+      </AccordionDetails>
+    );
+  } else {
+    return <div className={classes.noWalletButtonCon}>
+      <Button className={classes.noWalletButton} onClick={handleConnectWallet}>{t('Vault-ConnectWallet')}</Button>
+    </div>
+  }
 };
 
 export default PoolDetails;

--- a/src/features/vault/components/PoolDetails/styles.js
+++ b/src/features/vault/components/PoolDetails/styles.js
@@ -1,0 +1,20 @@
+import { primaryColor } from 'assets/jss/material-kit-pro-react.js';
+
+const styles = theme => ({
+  noWalletButtonCon: {
+    display: 'flex',
+    justifyContent: 'space-around',
+  },
+  noWalletButton: {
+    margin: '20px 0',
+    fontSize: '14px',
+    fontWeight: 'bold',
+    borderRadius: '5px',
+    backgroundColor: primaryColor[0],
+    '& .MuiButton-label': {
+      color: 'white',
+    },
+  }
+});
+
+export default styles;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2,6 +2,7 @@
   "Disclaimer": "Using Smart Contracts, Tokens, and Crypto is always a risk. DYOR before investing.",
   "Network-Error": "Connect to the correct network please.",
   "Vault-Wallet": "Wallet",
+  "Vault-ConnectWallet": "Connect Wallet",
   "Vault-Balance": "Balance",
   "Vault-APY": "APY",
   "Vault-APYDaily": "Daily",


### PR DESCRIPTION
The last task of issue #158 was "Prompt user to connect wallet upon clicking an action button". Instead I hid the deposit/withdraw area and replaced it with a "Connect wallet" button. Upon connecting a wallet, the normal deposit/withdraw area will show up. 

Added a new translation for "Connect Wallet". Do we also want the header wallet button to say "Connect Wallet"? It seems better to me than "? Wallet".