### PR TITLE
fix Uncaught TypeError

### DIFF
--- a/src/features/vault/components/PoolDetails/DepositSection/DepositSection.js
+++ b/src/features/vault/components/PoolDetails/DepositSection/DepositSection.js
@@ -64,7 +64,7 @@ const DepositSection = ({ pool, index, balanceSingle }) => {
     }
 
     let amountValue = depositBalance.amount
-      ? depositBalance.amount.replace(',', '')
+      ? depositBalance.amount.toString().replace(',', '')
       : depositBalance.amount;
 
     if (pool.tokenAddress) {


### PR DESCRIPTION
A fix to #292 , the error was produced because the depositBalance.amount wasn't a string after pressing desositAll. Tested in 2 vaults.