### PR TITLE
Add missing platform entry for non-eol pools

### DIFF
--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -665,6 +665,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Marshmallow',
     assets: ['MASH', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -691,6 +692,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Marshmallow',
     assets: ['MASH', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -717,6 +719,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Marshmallow',
     assets: ['MASH'],
     callFee: 0.5,
     buyTokenUrl:
@@ -770,6 +773,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'YieldBay',
     assets: ['PALM'],
     callFee: 0.5,
     buyTokenUrl:
@@ -1470,6 +1474,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['TYPH', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -1497,6 +1502,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['BITI', 'BNB'],
     callFee: 0.25,
     addLiquidityUrl:
@@ -1524,6 +1530,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'YieldBay',
     assets: ['PALM', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -1550,6 +1557,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'YieldBay',
     assets: ['PALM', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -1737,6 +1745,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['BGO', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -1763,6 +1772,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['sBGO', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -2205,6 +2215,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'BillionHappiness',
     assets: ['HPS'],
     callFee: 0.5,
     buyTokenUrl:
@@ -2229,6 +2240,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'JulSwap',
     assets: ['HPS', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl: 'https://julswap.com/#/add/BNB/0xeDa21B525Ac789EaB1a08ef2404dd8505FfB973D',
@@ -2588,6 +2600,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pumpy',
     assets: ['PMP', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -2723,6 +2736,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Complus',
     assets: ['COM', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -2861,6 +2875,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Squirrel',
     assets: ['NUTS'],
     callFee: 0.5,
     buyTokenUrl:
@@ -2914,6 +2929,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['APE', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -2940,6 +2956,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['MFRM', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -2967,6 +2984,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'SlimeFinance',
     assets: ['SLME', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -2993,6 +3011,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'SlimeFinance',
     assets: ['SLME', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -3736,6 +3755,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['SOUP', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -3762,6 +3782,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['SOUPS', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4068,6 +4089,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Sponge',
     assets: ['STEAM', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4095,6 +4117,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'SaltSwap',
     assets: ['SALT', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4121,6 +4144,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'SaltSwap',
     assets: ['SALT', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4176,6 +4200,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['CROW', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4203,6 +4228,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['CROW', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4230,6 +4256,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'RamenSwap',
     assets: ['RAMEN', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4257,6 +4284,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'RamenSwap',
     assets: ['RAMEN', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4284,6 +4312,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'CafeSwap',
     assets: ['BREW', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4311,6 +4340,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'CafeSwap',
     assets: ['BREW', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4338,6 +4368,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'CafeSwap',
     assets: ['BIFI', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4589,6 +4620,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'Pancake',
     assets: ['MSC', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4616,6 +4648,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'Pancake',
     assets: ['MSC', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4643,6 +4676,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['BTS', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -4669,6 +4703,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Pancake',
     assets: ['BTD', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -5070,6 +5105,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Sponge',
     assets: ['SPG', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -5097,6 +5133,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Sponge',
     assets: ['SOAK', 'BNB'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -5152,6 +5189,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'Nyanswop',
     assets: ['NYAS', 'USDT'],
     callFee: 0.5,
   },
@@ -5175,6 +5213,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'Pancake',
     assets: ['MSS', 'BUSD'],
     callFee: 0.5,
     addLiquidityUrl:
@@ -5562,6 +5601,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'BillionHappiness',
     assets: ['BHC'],
     callFee: 0.5,
     buyTokenUrl:
@@ -7252,6 +7292,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Narwhal',
     assets: ['GOLD', 'BNB'],
     callFee: 1,
     addLiquidityUrl:
@@ -7986,6 +8027,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'ForTube',
     assets: ['FIL'],
     callFee: 1,
   },
@@ -8009,6 +8051,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'ForTube',
     assets: ['BUSD'],
     callFee: 1,
   },
@@ -8032,6 +8075,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'ForTube',
     assets: ['LINK'],
     callFee: 1,
   },
@@ -8055,6 +8099,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'ForTube',
     assets: ['DOT'],
     callFee: 1,
   },
@@ -8078,6 +8123,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'ForTube',
     assets: ['USDT'],
     callFee: 1,
   },
@@ -8101,6 +8147,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: true,
     status: 'active',
+    platform: 'ForTube',
     assets: ['BTCB'],
     callFee: 1,
   },


### PR DESCRIPTION
Some pools had the platform key missing causing them not to show up if a platform was selected in the filters.

I'll tackle the 29 eol ones when I get time.