### PR TITLE
add quick and dirty filter to show only Pancake V2 vaults

### DIFF
--- a/src/features/vault/components/Filters/Filters.js
+++ b/src/features/vault/components/Filters/Filters.js
@@ -139,12 +139,12 @@ const Filters = ({
             className={classes.label}
             control={
               <Checkbox
-                checked={filters.showExperimental}
-                onChange={() => toggleFilter('showExperimental')}
+                checked={filters.showPancakeSwapV2Only}
+                onChange={() => toggleFilter('showPancakeSwapV2Only')}
                 color="primary"
               />
             }
-            label={t('Experimental')}
+            label={t('PancakeSwap V2')}
           />
         </FormControl>
       </Grid>

--- a/src/features/vault/hooks/useFilteredPools.js
+++ b/src/features/vault/hooks/useFilteredPools.js
@@ -7,6 +7,7 @@ const DEFAULT = {
   hideZeroVaultBalances: false,
   showBoosted: false,
   showExperimental: false,
+  showPancakeSwapV2Only: false,
 };
 
 const KEY = 'filteredPools';
@@ -45,15 +46,25 @@ const useFilteredPools = (pools, tokens) => {
     filteredPools = hideDecomissioned(filteredPools, tokens);
   }
 
-
   if(filters.showBoosted) {
     filteredPools = showBoosted(filteredPools);
   }
 
   filteredPools = Experimental(filteredPools, filters.showExperimental);
 
+  if (filters.showPancakeSwapV2Only) {
+    filteredPools = hideNonPancakeSwapV2(filteredPools);
+  }
+
   return { filteredPools, toggleFilter, filters };
 };
+
+function hideNonPancakeSwapV2(pools) {
+  return pools.filter(pool => {
+    // quick hack to avoid adding another flag to bsc_pools.js
+    return pool.id.substr(0, 7) === 'cakev2-';
+  });
+}
 
 function Experimental(pools, show) {
   return pools.filter(pool => {


### PR DESCRIPTION
add quick and dirty filter to show only Pancake V2 vaults.
replaces experimental filter.

using a quick hack to identify the V2 vaults by checking if the id starts with "cakev2-" - otherwise we'd need to add a flag to every pool.

please check it works :)