### PR TITLE
Remove import from top of bsc_pools.js

### DIFF
--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -1,5 +1,3 @@
-import { TrafficOutlined } from '@material-ui/icons';
-
 export const bscPools = [
   {
     id: 'bifi-maxi',


### PR DESCRIPTION
It breaks the dashboard: https://github.com/beefyfinance/beefy-dashboard/blob/master/src/utils/getVaults.js

Also not sure how it keeps getting added in there.