### PR TITLE
Cleaning bsc_pools.js

### DIFF
--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -4055,6 +4055,8 @@ export const bscPools = [
     status: 'active',
     assets: ['MASH', 'BUSD'],
     callFee: 0.5,
+    addLiquidityUrl:
+      'https://exchange.marshmallowdefi.com/#/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x787732f27D18495494cea3792ed7946BbCFF8db2',
     buyTokenUrl:
       'https://exchange.marshmallowdefi.com/#/swap?outputCurrency=0x787732f27D18495494cea3792ed7946BbCFF8db2',
   },
@@ -4079,6 +4081,8 @@ export const bscPools = [
     status: 'active',
     assets: ['MASH', 'BNB'],
     callFee: 0.5,
+    addLiquidityUrl:
+      'https://exchange.marshmallowdefi.com/#/add/ETH/0x787732f27D18495494cea3792ed7946BbCFF8db2',
     buyTokenUrl:
       'https://exchange.marshmallowdefi.com/#/swap?outputCurrency=0x787732f27D18495494cea3792ed7946BbCFF8db2',
   },

--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -4055,8 +4055,6 @@ export const bscPools = [
     status: 'active',
     assets: ['MASH', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.marshmallowdefi.com/#/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x787732f27D18495494cea3792ed7946BbCFF8db2',
     buyTokenUrl:
       'https://exchange.marshmallowdefi.com/#/swap?outputCurrency=0x787732f27D18495494cea3792ed7946BbCFF8db2',
   },
@@ -4081,8 +4079,6 @@ export const bscPools = [
     status: 'active',
     assets: ['MASH', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.marshmallowdefi.com/#/add/ETH/0x787732f27D18495494cea3792ed7946BbCFF8db2',
     buyTokenUrl:
       'https://exchange.marshmallowdefi.com/#/swap?outputCurrency=0x787732f27D18495494cea3792ed7946BbCFF8db2',
   },
@@ -4841,8 +4837,6 @@ export const bscPools = [
     platform: 'Autofarm',
     assets: ['AUTO', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xa184088a740c695E156F91f5cC086a06bb78b827',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xa184088a740c695E156F91f5cC086a06bb78b827',
   },
@@ -4893,8 +4887,6 @@ export const bscPools = [
     status: 'active',
     assets: ['BITI', 'BNB'],
     callFee: 0.25,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xA25Dab5B75aC0E0738E58E49734295baD43d73F1',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xA25Dab5B75aC0E0738E58E49734295baD43d73F1',
   },
@@ -5078,10 +5070,8 @@ export const bscPools = [
     platform: 'Swamp',
     assets: ['BIFI', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xCa3F508B8e4Dd382eE878A314789373D80A5190A',
-    buyTokenUrl:
-      'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xCa3F508B8e4Dd382eE878A314789373D80A5190A',
+    removeLiquidityUrl:
+      'https://v1exchange.pancakeswap.finance/#/remove/BNB/0xCa3F508B8e4Dd382eE878A314789373D80A5190A',
   },
 
   {
@@ -5131,8 +5121,6 @@ export const bscPools = [
     status: 'active',
     assets: ['BGO', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x579a6277a6c2c63a5b25006f63bce5dc8d9c25e7',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x579a6277a6c2c63a5b25006f63bce5dc8d9c25e7',
   },
@@ -5157,8 +5145,6 @@ export const bscPools = [
     status: 'active',
     assets: ['sBGO', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x53f39324fbb209693332b87aa94d5519a1a49ab0',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x53f39324fbb209693332b87aa94d5519a1a49ab0',
   },
@@ -5368,8 +5354,6 @@ export const bscPools = [
     status: 'active',
     assets: ['SWIRL', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x52d86850bc8207b520340B7E39cDaF22561b9E56',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x52d86850bc8207b520340B7E39cDaF22561b9E56',
   },
@@ -5523,10 +5507,8 @@ export const bscPools = [
     status: 'eol',
     assets: ['ZEFI', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://swap.zcore.network/#/add/BNB/0x0288D3E353fE2299F11eA2c2e1696b4A648eCC07',
-    buyTokenUrl:
-      'https://swap.zcore.network/#/swap?outputCurrency=0x0288D3E353fE2299F11eA2c2e1696b4A648eCC07',
+    removeLiquidityUrl:
+      'https://v1exchange.pancakeswap.finance/#/remove/BNB/0x0288D3E353fE2299F11eA2c2e1696b4A648eCC07',
   },
   {
     id: 'zefi-zefi-busd',
@@ -5549,10 +5531,8 @@ export const bscPools = [
     status: 'eol',
     assets: ['ZEFI', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://swap.zcore.network/#/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x0288D3E353fE2299F11eA2c2e1696b4A648eCC07',
-    buyTokenUrl:
-      'https://swap.zcore.network/#/swap?outputCurrency=0x0288D3E353fE2299F11eA2c2e1696b4A648eCC07',
+    removeLiquidityUrl:
+      'https://v1exchange.pancakeswap.finance/#/remove/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x0288D3E353fE2299F11eA2c2e1696b4A648eCC07',
   },
 
   {
@@ -5841,8 +5821,6 @@ export const bscPools = [
     platform: 'Pancake',
     assets: ['SPACE', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x0abd3E3502c15ec252f90F64341cbA74a24fba06',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x0abd3E3502c15ec252f90F64341cbA74a24fba06',
   },
@@ -5868,8 +5846,6 @@ export const bscPools = [
     platform: 'Pancake',
     assets: ['SPACE', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x0abd3E3502c15ec252f90F64341cbA74a24fba06',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0x0abd3E3502c15ec252f90F64341cbA74a24fba06&outputCurrency=0xe9e7cea3dedca5984780bafc599bd69add087d56',
   },
@@ -6261,8 +6237,6 @@ export const bscPools = [
     status: 'active',
     assets: ['APE', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xa9eA4b786ee5b7A733c035564Bfd9341A4c9FC1e',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xa9eA4b786ee5b7A733c035564Bfd9341A4c9FC1e',
   },
@@ -6287,8 +6261,6 @@ export const bscPools = [
     status: 'active',
     assets: ['MFRM', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x206340f3361404910F45cA0893980EF3f9b418ea',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x206340f3361404910F45cA0893980EF3f9b418ea',
   },
@@ -7047,8 +7019,6 @@ export const bscPools = [
     status: 'active',
     assets: ['SOUP', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x94F559aE621F1c810F31a6a620Ad7376776fe09E',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x94F559aE621F1c810F31a6a620Ad7376776fe09E',
   },
@@ -7073,8 +7043,6 @@ export const bscPools = [
     status: 'active',
     assets: ['SOUPS', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x69f27e70e820197a6e495219d9ac34c8c6da7eee',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x69f27e70e820197a6e495219d9ac34c8c6da7eee',
   },
@@ -7365,8 +7333,6 @@ export const bscPools = [
     status: 'active',
     assets: ['STEAM', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x072e3d0d4f14dd82a16b0a33678c6104e9009ed9',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x072e3d0d4f14dd82a16b0a33678c6104e9009ed9',
   },
@@ -7471,8 +7437,6 @@ export const bscPools = [
     status: 'active',
     assets: ['CROW', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xe9e7cea3dedca5984780bafc599bd69add087d56/0xcc2E12a9b5b75360c6FBf23B584c275D52cDdb0',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0xcc2E12a9b5b75360c6FBf23B584c275D52cDdb0&outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },
@@ -7498,8 +7462,6 @@ export const bscPools = [
     status: 'active',
     assets: ['CROW', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xcc2E12a9b5b75360c6FBf23B584c275D52cDdb0E',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=ETH&outputCurrency=0xcc2E12a9b5b75360c6FBf23B584c275D52cDdb0E',
   },
@@ -7846,8 +7808,6 @@ export const bscPools = [
     status: 'active',
     assets: ['MSC', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0x8C784C49097Dcc637b93232e15810D53871992BF',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0x8C784C49097Dcc637b93232e15810D53871992BF&outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },
@@ -7873,8 +7833,6 @@ export const bscPools = [
     status: 'active',
     assets: ['MSC', 'BNB'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x8C784C49097Dcc637b93232e15810D53871992BF',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x8C784C49097Dcc637b93232e15810D53871992BF',
   },
@@ -7900,8 +7858,6 @@ export const bscPools = [
     status: 'active',
     assets: ['BTS', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xc2e1acef50ae55661855e8dcb72adb182a3cc259/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0xc2e1acef50ae55661855e8dcb72adb182a3cc259&outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },
@@ -7926,8 +7882,6 @@ export const bscPools = [
     status: 'active',
     assets: ['BTD', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xD1102332a213E21faF78B69C03572031F3552c33/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0xD1102332a213E21faF78B69C03572031F3552c33&outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },
@@ -8422,8 +8376,6 @@ export const bscPools = [
     status: 'active',
     assets: ['MSS', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xacabd3f9b8f76ffd2724604185fa5afa5df25ac6/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56&outputCurrency=0xacabd3f9b8f76ffd2724604185fa5afa5df25ac6',
   },
@@ -9022,8 +8974,6 @@ export const bscPools = [
     status: 'active',
     assets: ['SBDO', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0xe9e7cea3dedca5984780bafc599bd69add087d56/0x0d9319565be7f53cefe84ad201be3f40feae2740',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0xe9e7cea3dedca5984780bafc599bd69add087d56&outputCurrency=0x0d9319565be7f53cefe84ad201be3f40feae2740',
   },
@@ -9049,8 +8999,6 @@ export const bscPools = [
     status: 'active',
     assets: ['BDO', 'BUSD'],
     callFee: 0.5,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/0x190b589cf9Fb8DDEabBFeae36a813FFb2A702454/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0x190b589cf9Fb8DDEabBFeae36a813FFb2A702454&outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },
@@ -9481,8 +9429,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['FUEL', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x2090c8295769791ab7a3cf1cc6e0aa19f35e441a',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x2090c8295769791ab7a3cf1cc6e0aa19f35e441a',
   },
@@ -9509,8 +9455,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['FUEL', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x2090c8295769791ab7A3CF1CC6e0AA19F35e441A',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x2090c8295769791ab7A3CF1CC6e0AA19F35e441A',
   },
@@ -9537,8 +9481,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['BHC', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x6fd7c98458a943f469e1cf4ea85b173f5cd342f4',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x6fd7c98458a943f469e1cf4ea85b173f5cd342f4',
   },
@@ -9565,8 +9507,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['ETH', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x2170ed0880ac9a755fd29b2688956bd959f933f8',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x2170ed0880ac9a755fd29b2688956bd959f933f8',
   },
@@ -9593,8 +9533,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['CAKE', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
   },
@@ -9621,8 +9559,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['UNI', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xbf5140a22578168fd562dccf235e5d43a02ce9b1',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xbf5140a22578168fd562dccf235e5d43a02ce9b1',
   },
@@ -9649,8 +9585,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['LINK', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xf8a0bf9cf54bb92f17374d9e9a321e6a111a51bd',
   },
@@ -9677,8 +9611,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['BUSD', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },
@@ -9705,8 +9637,6 @@ export const bscPools = [
     platform: 'JetFuel',
     assets: ['USDT', 'BNB'],
     callFee: 1,
-    addLiquidityUrl:
-      'https://exchange.pancakeswap.finance/#/add/BNB/0x55d398326f99059ff775485246999027b3197955',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0x55d398326f99059ff775485246999027b3197955',
   },


### PR DESCRIPTION
### **Motivation:**
- Removing "Add Liquidity" from old Cake v1 LPs will prohibit users from wasting gas to adding/removing Cake v2 Liquidity.
- Reduce bsc_pools.js lines a bit.

### **Vaults that should be considered to be marked as EOL (these are vault ids):**
auto-busd-old
jetfuel-fuel-bnb-pcs
fortube-fil
fortube-busd
fortube-link
fortube-dot
fortube-usdt
fortube-btcb
biti-biti-bnb
monster-msc-busd
monster-msc-bnb
monster-mss-busd

**_Active vaults with Cake v1 LPs that their "Add Liquidity" button got removed:_**
BGO-BUSD
SBGO-BUSD
AUTO-BNB
BITI-BNB
SWIRL-BNB
SPACE-BUSD
SPACE-BNB
APE-BNB
MFRM-BNB
SOUP-BNB
SOUPS-BNB
STEAM-BNB
CROW-BUSD
CROW-BNB
MSC-BUSD
MSC-BNB
BTS-BUSD
BTD-BUSD
MSS-BUSD
SBDO-BUSD
BDO-BUSD
FUEL-BNB
BHC-BNB(Jetfuel)
ETH-BNB(Jetfuel)
CAKE-BNB(Jetfuel)
UNI-BNB(Jetfuel)
LINK-BNB(Jetfuel)
BUSD-BNB(Jetfuel)
USDT-BNB(Jetfuel)

**_EOL vaults that got "Remove Liquidity" button:_**
Swamp's BIFI-BNB
ZEFI-BNB
ZEFI-BUSD