### PR TITLE
Responsive fix for barn/vote/stats/docs links

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -48,8 +48,8 @@ const Header = ({ links, isNightMode, setNightMode }) => {
           </Hidden>
         </Button>
 
-        <span>
-          <Hidden mdDown>
+        <div className={classes.middleNav}>
+          <Hidden smDown>
             {Number(process.env.REACT_APP_NETWORK_ID) === 56 &&
               renderLink('barn', 'barn', 'warehouse', classes)}
             {renderLink('vote', 'vote', 'vote-yea', classes)}
@@ -58,7 +58,7 @@ const Header = ({ links, isNightMode, setNightMode }) => {
           </Hidden>
           {renderLink('buy', t('buy'), 'dollar-sign', classes)}
           {renderBoost(classes)}
-        </span>
+        </div>
 
         <Hidden smDown implementation="css">
           <div className={classes.collapse}>{links}</div>

--- a/src/components/Header/styles.js
+++ b/src/components/Header/styles.js
@@ -1,17 +1,17 @@
 import {
-  container,
-  primaryColor,
-  infoColor,
-  successColor,
-  warningColor,
-  dangerColor,
-  roseColor,
-  transition,
-  boxShadow,
   blackColor,
-  whiteColor,
+  boxShadow,
+  containerFluid,
+  dangerColor,
   grayColor,
   hexToRgb,
+  infoColor,
+  primaryColor,
+  roseColor,
+  successColor,
+  transition,
+  warningColor,
+  whiteColor,
 } from 'assets/jss/material-kit-pro-react.js';
 
 const styles = theme => ({
@@ -44,19 +44,15 @@ const styles = theme => ({
     position: 'fixed',
   },
   container: {
-    ...container,
+    ...containerFluid,
     minHeight: '50px',
     alignItems: 'center',
     justifyContent: 'space-between',
     display: 'flex',
     flexWrap: 'nowrap',
-    '@media (min-width: 992px)': {
-      width: '100%',
-      maxWidth: '960px',
-    },
     '@media (min-width: 1230px)': {
-      width: '100%',
-      maxWidth: '1230px',
+      width: '1230px',
+      maxWidth: '100%',
     },
   },
   title: {
@@ -221,7 +217,13 @@ const styles = theme => ({
   logo: {
     marginRight: '12px',
   },
+  middleNav: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   link: {
+    display: 'inline-flex',
     margin: '0 1rem',
     fontSize: '1rem',
     fontWeight: 400,
@@ -233,12 +235,18 @@ const styles = theme => ({
     '& span': {
       color: theme.palette.text.primary,
     },
+    '@media (min-width: 960px) and (max-width: 1110px)': {
+      '& $icon': {
+        display: 'none',
+      }
+    },
   },
   icon: {
     color: theme.palette.text.primary,
     marginRight: '0.5rem',
     minWidth: '24px',
     textAlign: 'end',
+    display: 'none',
   },
   iconButton: {
     color: theme.palette.text.primary,


### PR DESCRIPTION
Makes header container wider and hides icons as required to ensure barn/vote/stats/docs/buy/boost links are always available in the nav (on screen sizes where the drawer does not show)

Fixes #211 