### PR TITLE
Code tidy to remove warnings

### DIFF
--- a/src/features/stake/sections/StakePool.js
+++ b/src/features/stake/sections/StakePool.js
@@ -40,7 +40,7 @@ const useStyles = makeStyles(styles);
 
 export default function StakePool(props) {
   const classes = useStyles();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { address } = useConnectWallet();
   const { allowance, checkApproval } = useCheckApproval();
   const { balance, fetchBalance } = useFetchBalance();
@@ -90,17 +90,18 @@ export default function StakePool(props) {
     }
   };
 
+  const urlIndex = props.match.params.index;
   useEffect(() => {
-    setIndex(Number(props.match.params.index) - 1);
-  }, [Number(props.match.params.index)]);
+    setIndex(Number(urlIndex) - 1);
+  }, [urlIndex]);
 
   useEffect(() => {
     setIsNeedApproval(Boolean(allowance[index] === 0));
-  }, [allowance[index], index]);
+  }, [allowance, index]);
 
   useEffect(() => {
     setApprovalAble(!Boolean(fetchApprovalPending[index]));
-  }, [fetchApprovalPending[index], index]);
+  }, [fetchApprovalPending, index]);
 
   const onApproval = () => {
     fetchApproval(index);
@@ -108,7 +109,7 @@ export default function StakePool(props) {
 
   useEffect(() => {
     setStakeAble(!Boolean(fetchStakePending[index]));
-  }, [fetchStakePending[index], index]);
+  }, [fetchStakePending, index]);
 
   const onStake = () => {
     const amount = new BigNumber(inputVal)
@@ -121,7 +122,7 @@ export default function StakePool(props) {
   useEffect(() => {
     const isPending = Boolean(fetchWithdrawPending[index]);
     setWithdrawAble(!isPending);
-  }, [fetchWithdrawPending[index], index]);
+  }, [fetchWithdrawPending, index]);
 
   const onWithdraw = () => {
     const amount = new BigNumber(inputVal)
@@ -135,7 +136,7 @@ export default function StakePool(props) {
     const isPending = Boolean(fetchClaimPending[index]);
     const rewardsAvailableIs0 = rewardsAvailable[index] === 0;
     setClaimAble(!Boolean(isPending || rewardsAvailableIs0));
-  }, [rewardsAvailable[index], fetchClaimPending[index], index]);
+  }, [rewardsAvailable, fetchClaimPending, index]);
 
   const onClaim = () => {
     fetchClaim(index);
@@ -144,7 +145,7 @@ export default function StakePool(props) {
   useEffect(() => {
     const isPending = Boolean(fetchExitPending[index]);
     setExitAble(!Boolean(isPending));
-  }, [fetchExitPending[index], index]);
+  }, [fetchExitPending, index]);
 
   const onExit = () => {
     fetchExit(index);
@@ -153,12 +154,12 @@ export default function StakePool(props) {
   useEffect(() => {
     const amount = byDecimals(balance[index], pools[index].tokenDecimals);
     setMyBalance(amount);
-  }, [balance[index], index]);
+  }, [balance, pools, index]);
 
   useEffect(() => {
     const amount = byDecimals(currentlyStaked[index], pools[index].tokenDecimals);
     setMyCurrentlyStaked(amount);
-  }, [currentlyStaked[index], index]);
+  }, [currentlyStaked, pools, index]);
 
   useEffect(() => {
     let amount = byDecimals(rewardsAvailable[index], pools[index].earnedTokenDecimals);
@@ -166,7 +167,7 @@ export default function StakePool(props) {
       amount = amount.multipliedBy(96).dividedBy(100);
     }
     setMyRewardsAvailable(amount);
-  }, [rewardsAvailable[index], index]);
+  }, [rewardsAvailable, pools, index]);
 
   useEffect(() => {
     if (halfTime[index] === 0) {
@@ -189,7 +190,7 @@ export default function StakePool(props) {
     formatTime();
     const id = setInterval(formatTime, 1000);
     return () => clearInterval(id);
-  }, [halfTime[index], pools, index]);
+  }, [halfTime, pools, index, fetchHalfTime]);
 
   useEffect(() => {
     if (address) {
@@ -211,7 +212,7 @@ export default function StakePool(props) {
       fetchPoolData(index);
     }, 10000);
     return () => clearInterval(id);
-  }, [address, index]);
+  }, [address, index, checkApproval, fetchBalance, fetchCurrentlyStaked, fetchRewardsAvailable, fetchHalfTime, fetchPoolData]);
 
   const handleModal = (state, action = false) => {
     setOpen(state);
@@ -372,7 +373,7 @@ export default function StakePool(props) {
                     />
                   </Box>
                   <Box>
-                    <img className={classes.boostImg} src={require('images/stake/boost.svg')} />
+                    <img className={classes.boostImg} src={require('images/stake/boost.svg')} alt={t('Boost')}/>
                   </Box>
                 </Box>
               ) : (
@@ -504,7 +505,7 @@ export default function StakePool(props) {
                       />
                     </Box>
                     <Box>
-                      <img className={classes.boostImg} src={require('images/stake/boost.svg')} />
+                      <img className={classes.boostImg} src={require('images/stake/boost.svg')} alt={t('Boost')} />
                     </Box>
                   </Box>
                 ) : (

--- a/src/features/stake/sections/StakePools.js
+++ b/src/features/stake/sections/StakePools.js
@@ -110,7 +110,7 @@ export default function StakePools(props) {
       <Grid container spacing={4} justify={'center'}>
         {pools.map((pool, index) => (
           <React.Fragment key={index}>
-            {(showPools === 'all' || (showPools === 'active' && pools[index].status === showPools || showPools === 'active' && pools[index].status === 'soon') || showPools === 'closed' && pools[index].status === showPools) ? (
+            {(showPools === 'all' || (showPools === 'active' && (pools[index].status === showPools || pools[index].status === 'soon')) || (showPools === 'closed' && pools[index].status === showPools) ) ? (
               <Grid xs={12} sm={6} md={6} lg={3} key={index} item>
                 <Grid
                   className={[

--- a/src/features/vault/components/Pool/Pool.js
+++ b/src/features/vault/components/Pool/Pool.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, memo, useEffect } from 'react';
+import React, { useState, useCallback, memo } from 'react';
 import Accordion from '@material-ui/core/Accordion';
 import Divider from '@material-ui/core/Divider';
 import Grid from '@material-ui/core/Grid';
@@ -9,7 +9,6 @@ import { byDecimals } from 'features/helpers/bignumber';
 import PoolSummary from '../PoolSummary/PoolSummary';
 import PoolDetails from '../PoolDetails/PoolDetails';
 import styles from './styles';
-import { useFetchPoolData } from '../../../stake/redux/fetchPoolData';
 import { useSelector } from 'react-redux';
 
 const useStyles = makeStyles(styles);

--- a/src/features/vault/components/VisiblePools/VisiblePools.js
+++ b/src/features/vault/components/VisiblePools/VisiblePools.js
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react';
+import React, {useEffect, useMemo} from 'react';
 
 import InfiniteScroll from 'react-infinite-scroll-component';
-import { useTranslation } from 'react-i18next';
-import { makeStyles } from '@material-ui/core/styles';
+import {useTranslation} from 'react-i18next';
+import {makeStyles} from '@material-ui/core/styles';
 import styles from './styles';
 
 import useFilteredPools from '../../hooks/useFilteredPools';
@@ -14,7 +14,7 @@ import useVisiblePools from '../../hooks/useVisiblePools';
 
 import Pool from '../Pool/Pool';
 import Filters from '../Filters/Filters';
-import { useFetchPoolData } from '../../../stake/redux/fetchPoolData';
+import {useFetchPoolData} from '../../../stake/redux/fetchPoolData';
 
 const useStyles = makeStyles(styles);
 
@@ -36,28 +36,31 @@ const VisiblePools = ({
   const { sortedPools, order, setOrder } = useSortedPools(poolsByAsset, apys, tokens);
   const { visiblePools, fetchVisiblePools } = useVisiblePools(sortedPools, 10);
   const { pools: stake, fetchPoolData } = useFetchPoolData();
-  const indexes = [];
 
-  useEffect(() => {
-    const timestamp = Math.floor(Date.now() / 1000);
-    for (let index in stake) {
-      if(stake[index].periodFinish >= timestamp) {
-        for(let key in pools) {
-          if(stake[index].token === pools[key].earnedToken) {
+  const activeLaunchPoolIndexes = useMemo(() => {
+    const indexes = [];
+    const now = Math.floor(Date.now() / 1000);
+
+    for (let index = 0; index < stake.length; ++index) {
+      if (stake[index].periodFinish >= now) {
+        for (let key = 0; key < pools.length; ++key) {
+          if (stake[index].token === pools[key].earnedToken) {
             pools[key].launchpool = stake[index].id;
-            if(!indexes.includes(index)) {
-              indexes.push(index);
-            }
-            continue;
+            indexes.push(index);
+
+            // each vault can only have one launch pool reference
+            break;
           }
         }
       }
     }
-  }, []);
+
+    return indexes;
+  }, [pools, stake]);
 
   useEffect(() => {
-    fetchPoolData(indexes);
-  }, [fetchPoolData]);
+    fetchPoolData(activeLaunchPoolIndexes);
+  }, [fetchPoolData, activeLaunchPoolIndexes]);
 
   return (
     <>

--- a/src/features/vault/components/VisiblePools/VisiblePools.js
+++ b/src/features/vault/components/VisiblePools/VisiblePools.js
@@ -1,8 +1,8 @@
-import React, {useEffect, useMemo} from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import InfiniteScroll from 'react-infinite-scroll-component';
-import {useTranslation} from 'react-i18next';
-import {makeStyles} from '@material-ui/core/styles';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from '@material-ui/core/styles';
 import styles from './styles';
 
 import useFilteredPools from '../../hooks/useFilteredPools';
@@ -14,7 +14,7 @@ import useVisiblePools from '../../hooks/useVisiblePools';
 
 import Pool from '../Pool/Pool';
 import Filters from '../Filters/Filters';
-import {useFetchPoolData} from '../../../stake/redux/fetchPoolData';
+import { useFetchPoolData } from '../../../stake/redux/fetchPoolData';
 
 const useStyles = makeStyles(styles);
 

--- a/src/features/web3/fetchPrice.js
+++ b/src/features/web3/fetchPrice.js
@@ -2,8 +2,6 @@ import axios from 'axios';
 
 import { getNetworkPools, getNetworkStakePools } from '../helpers/getNetworkData';
 
-const t = () => Math.trunc(Date.now() / (5 * 60 * 1000));
-
 const endpoints = {
   coingecko: 'https://api.coingecko.com/api/v3/simple/price',
 };
@@ -16,10 +14,6 @@ const priceCache = {
   cache: new Map(),
   lastUpdated: undefined,
 };
-
-function isCached(id) {
-  return priceCache.cache.has(id);
-}
 
 function getCachedPrice(id) {
   return priceCache.cache.get(id);


### PR DESCRIPTION
**no-unused-vars**
removed the unused variables

**no-mixed-operators**
straightforward tidy of a conditional

**jsx-a11y/alt-text**
added missing alt tag on boost images

**react-hooks/exhaustive-deps**
missing dependency -> added the missing dependency

complex expression -> a lot of these had dependencies in the form of `array[index]`; swapped to `array, index` which should be fine so long as `array` follows the usual react rules of being re-built rather than edited. Everything looked like it came from a redux store so that should be the case. If you know of any cases where this isn't the case let me know and I can break the dependency out to a variable so that it can be statically checked by the linter.

For the indexes of launch (stake) pools needed by vault pools, I refactored to `useMemo` rather than `useEffect`.

Closes #196