### PR TITLE
Add chain-specific transaction links to notifications

### DIFF
--- a/src/common/networkSetup.js
+++ b/src/common/networkSetup.js
@@ -9,6 +9,7 @@ const networkSettings = {
     },
     rpcUrls: ['https://bsc-dataseed.binance.org'],
     blockExplorerUrls: ['https://bscscan.com/'],
+    txUrl: (hash) => `https://bscscan.com/tx/${hash}`,
   },
   '128': {
     chainId: `0x${parseInt(128, 10).toString(16)}`,
@@ -20,6 +21,7 @@ const networkSettings = {
     },
     rpcUrls: ['https://http-mainnet.hecochain.com'],
     blockExplorerUrls: ['https://hecoinfo.com/'],
+    txUrl: (hash) => `https://hecoinfo.com/tx/${hash}`,
   },
   '43114': {
     chainId: `0x${parseInt(43114, 10).toString(16)}`,
@@ -31,6 +33,7 @@ const networkSettings = {
     },
     rpcUrls: ['https://api.avax.network/ext/bc/C/rpc'],
     blockExplorerUrls: ['https://cchain.explorer.avax.network/'],
+    txUrl: (hash) => `https://cchain.explorer.avax.network/tx/${hash}/token-transfers`,
   },
   '137': {
     chainId: `0x${parseInt(137, 10).toString(16)}`,
@@ -42,6 +45,7 @@ const networkSettings = {
     },
     rpcUrls: ['https://rpc-mainnet.maticvigil.com/'],
     blockExplorerUrls: ['https://explorer.matic.network/'],
+    txUrl: (hash) => `https://explorer-mainnet.maticvigil.com/tx/${hash}/token-transfers`,
   }
 }
 
@@ -67,3 +71,5 @@ export const getRpcUrl = () => {
   const settings = networkSettings[process.env.REACT_APP_NETWORK_ID];
   return settings.rpcUrls[0];
 };
+
+export const getTxUrl = networkSettings[process.env.REACT_APP_NETWORK_ID].txUrl;

--- a/src/features/common/Notifier.js
+++ b/src/features/common/Notifier.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useSnackbar } from 'notistack';
 import { removeSnackbar } from './redux/actions';
 import Button from '@material-ui/core/Button';
+import { getTxUrl } from "../../common/networkSetup";
 
 let displayed = [];
 
@@ -45,7 +46,7 @@ const Notifier = () => {
           removeDisplayed(myKey);
         },
         autoHideDuration: 3000,
-        action: hash ? () => <Button onClick={() => window.open(`https://bscscan.com/tx/${hash}`, '_blank')}>View</Button> : null,
+        action: hash ? () => <Button onClick={() => window.open(getTxUrl(hash), '_blank')}>View</Button> : null,
       });
 
       // keep track of snackbars that we've displayed

--- a/src/features/stake/redux/fetchApproval.js
+++ b/src/features/stake/redux/fetchApproval.js
@@ -48,6 +48,7 @@ export function fetchApproval(index) {
             options: {
               variant: 'success',
             },
+            hash: receipt.transactionHash
           }));
           dispatch({ type: STAKE_FETCH_APPROVAL_SUCCESS, index });
           dispatch(checkApproval(index))

--- a/src/features/stake/redux/fetchExit.js
+++ b/src/features/stake/redux/fetchExit.js
@@ -46,6 +46,7 @@ export function fetchExit(index) {
             options: {
               variant: 'success',
             },
+            hash: receipt.transactionHash
           }));
           dispatch({ type: STAKE_FETCH_EXIT_SUCCESS, index });
           resolve();

--- a/src/features/stake/redux/fetchStake.js
+++ b/src/features/stake/redux/fetchStake.js
@@ -46,6 +46,7 @@ export function fetchStake(index, amount) {
             options: {
               variant: 'success',
             },
+            hash: receipt.transactionHash
           }));
           dispatch({ type: STAKE_FETCH_STAKE_SUCCESS, index });
           resolve();

--- a/src/features/stake/redux/fetchWithdraw.js
+++ b/src/features/stake/redux/fetchWithdraw.js
@@ -46,6 +46,7 @@ export function fetchWithdraw(index, amount) {
             options: {
               variant: 'success',
             },
+            hash: receipt.transactionHash
           }));
           dispatch({ type: STAKE_FETCH_WITHDRAW_SUCCESS, index });
           resolve();


### PR DESCRIPTION
Adds a new field to `networkSettings` for each chain which is a function that takes 1 parameter, a transaction hash, and returns a link to said transaction on a block explorer.

e.g. for BSC this is: ``txUrl: (hash) => `https://bscscan.com/tx/${hash}`,``

Exports this function from `networkSetup.js` as `getTxUrl`

`Notifier` uses this `getTxUrl` function to get the url for the 'View' button when `hash` is available in the notification data, instead of the hardcoded bscscan.com url.

Also adds the `hash` field for receipt notifications in `fetchApproval`, `fetchExit`, `fetchStake` and `fetchWithdraw`

Closes #386 

When https://github.com/beefyfinance/beefy-app/pull/387 gets merged a txUrl for Fantom will need added.