### PR TITLE
Fix zap swap estimation for big amounts

### DIFF
--- a/src/features/vault/redux/fetchZapEstimate.js
+++ b/src/features/vault/redux/fetchZapEstimate.js
@@ -7,6 +7,7 @@ import {
   VAULT_FETCH_ZAP_ESTIMATE_FAILURE,
 } from './constants';
 import { zapDepositEstimate, zapWithdrawEstimate } from '../../web3';
+import { convertAmountToRawNumber } from 'features/helpers/bignumber';
 
 export function fetchZapDepositEstimate({
   web3,
@@ -84,15 +85,17 @@ export function fetchZapWithdrawEstimate({
     const equity = shares.dividedBy(totalSupply);
     let amountIn, reserveIn, reserveOut;
     if (swapInput.address.toLowerCase() === pairToken.token0.toLowerCase()) {
-      amountIn = equity.multipliedBy(pairToken.reserves[0]).dividedToIntegerBy(1).toString();
+      amountIn = equity.multipliedBy(pairToken.reserves[0]);
       reserveIn = pairToken.reserves[0];
       reserveOut = pairToken.reserves[1];
     }
     if (swapInput.address.toLowerCase() === pairToken.token1.toLowerCase()) {
-      amountIn = equity.multipliedBy(pairToken.reserves[1]).dividedToIntegerBy(1).toString();
+      amountIn = equity.multipliedBy(pairToken.reserves[1]);
       reserveIn = pairToken.reserves[1];
       reserveOut = pairToken.reserves[0];
     }
+
+    amountIn = convertAmountToRawNumber(amountIn, 0);
 
     const promise = new Promise((resolve, reject) => {
       zapWithdrawEstimate({ web3, routerAddress, amountIn, reserveIn, reserveOut, dispatch })


### PR DESCRIPTION
**Problem:**

As reported by user `Anything over ~1016 crashes`

![](https://cdn.discordapp.com/attachments/845419578006831114/845419645635657798/unknown.png)
![](https://cdn.discordapp.com/attachments/845419578006831114/845419690179428402/unknown.png)

**Solution:**

Improve bigNumber to string conversion so there is no e+123 part.
