### PR TITLE
Fix Doge's decimals on bsc_tokenlist

### DIFF
--- a/src/features/configure/tokenlist/bsc_tokenlist.json
+++ b/src/features/configure/tokenlist/bsc_tokenlist.json
@@ -314,7 +314,7 @@
       "symbol": "DOGE",
       "address": "0xba2ae424d960c26247dd6c32edc70b295c744c43",
       "chainId": 56,
-      "decimals": 9,
+      "decimals": 8,
       "logoURI": "https://exchange.pancakeswap.finance/images/coins/0xba2ae424d960c26247dd6c32edc70b295c744c43.png"
     },
     {


### PR DESCRIPTION
silversurfer reported an issue with Doge's balance when using the Zap function. Phil helped to identify the problem. 