### PR TITLE
Fix tokenlist decimals

### DIFF
--- a/src/features/configure/tokenlist/bsc_tokenlist.json
+++ b/src/features/configure/tokenlist/bsc_tokenlist.json
@@ -8,10 +8,7 @@
   },
   "tags": {},
   "logoURI": "https://beefy.finance/img/beefy.svg",
-  "keywords": [
-    "beefy",
-    "bsc"
-  ],
+  "keywords": ["beefy", "bsc"],
   "tokens": [
     {
       "name": "Deri",
@@ -130,7 +127,7 @@
       "symbol": "tDOGE",
       "address": "0xe550a593d09FBC8DCD557b5C88Cea6946A8b404A",
       "chainId": 56,
-      "decimals": 18,
+      "decimals": 8,
       "logoURI": "https://exchange.pancakeswap.finance/images/coins/0xe550a593d09fbc8dcd557b5c88cea6946a8b404a.png"
     },
     {
@@ -138,7 +135,7 @@
       "symbol": "OIN",
       "address": "0x658E64FFcF40D240A43D52CA9342140316Ae44fA",
       "chainId": 56,
-      "decimals": 18,
+      "decimals": 8,
       "logoURI": "https://exchange.pancakeswap.finance/images/coins/0x658E64FFcF40D240A43D52CA9342140316Ae44fA.png"
     },
     {
@@ -178,7 +175,7 @@
       "symbol": "WMASS",
       "address": "0x7e396BfC8a2f84748701167c2d622F041A1D7a17",
       "chainId": 56,
-      "decimals": 18,
+      "decimals": 8,
       "logoURI": "https://exchange.pancakeswap.finance/images/coins/0x7e396bfc8a2f84748701167c2d622f041a1d7a17.png"
     },
     {
@@ -250,7 +247,7 @@
       "symbol": "BXBTC",
       "address": "0xab111D5948470Ba73d98D66BBdf2798FBE093546",
       "chainId": 56,
-      "decimals": 18,
+      "decimals": 9,
       "logoURI": "https://dex.apeswap.finance/images/coins/XBTC.svg"
     },
     {
@@ -258,7 +255,7 @@
       "symbol": "NAUT",
       "address": "0x05b339b0a346bf01f851dde47a5d485c34fe220c",
       "chainId": 56,
-      "decimals": 18,
+      "decimals": 8,
       "logoURI": "https://dex.apeswap.finance/images/coins/NAUT.png"
     },
     {
@@ -266,7 +263,7 @@
       "symbol": "IOTA",
       "address": "0xd944f1D1e9d5f9Bb90b62f9D45e447D989580782",
       "chainId": 56,
-      "decimals": 18,
+      "decimals": 6,
       "logoURI": "https://dex.apeswap.finance/images/coins/IOTA.png"
     },
     {
@@ -314,7 +311,7 @@
       "symbol": "DOGE",
       "address": "0xba2ae424d960c26247dd6c32edc70b295c744c43",
       "chainId": 56,
-      "decimals": 9,
+      "decimals": 8,
       "logoURI": "https://exchange.pancakeswap.finance/images/coins/0xba2ae424d960c26247dd6c32edc70b295c744c43.png"
     },
     {

--- a/src/features/configure/tokenlist/fantom_tokenlist.json
+++ b/src/features/configure/tokenlist/fantom_tokenlist.json
@@ -39,7 +39,7 @@
       "symbol": "WOOFY",
       "address": "0xD0660cD418a64a1d44E9214ad8e459324D8157f1",
       "chainId": 250,
-      "decimals": 18,
+      "decimals": 12,
       "logoURI": "https://raw.githubusercontent.com/yearn/yearn-assets/master/icons/tokens/0xD0660cD418a64a1d44E9214ad8e459324D8157f1/logo-128.png"
     },
     {


### PR DESCRIPTION
BSC:
[tDOGE](https://bscscan.com/token/0xe550a593d09fbc8dcd557b5c88cea6946a8b404a) was 18 should be 8
[OIN](https://bscscan.com/token/0x658e64ffcf40d240a43d52ca9342140316ae44fa) was 18 should be 8
[WMASS](https://bscscan.com/token/0x7e396bfc8a2f84748701167c2d622f041a1d7a17) was 18 should be 8
[BXBTC](https://bscscan.com/token/0xab111d5948470ba73d98d66bbdf2798fbe093546) was 18 should be 9
[NAUT](https://bscscan.com/token/0x05b339b0a346bf01f851dde47a5d485c34fe220c) was 18 should be 8
[IOTA](https://bscscan.com/token/0xd944f1d1e9d5f9bb90b62f9d45e447d989580782) was 18 should be 6
[DOGE](https://bscscan.com/token/0xba2ae424d960c26247dd6c32edc70b295c744c43) was 9 should be 8

Fantom:
[WOOFY](https://ftmscan.com/token/0xd0660cd418a64a1d44e9214ad8e459324d8157f1) was 18 should be 12