### PR TITLE
Changed Launchpool's APY to APR

### DIFF
--- a/src/features/stake/sections/StakePool.js
+++ b/src/features/stake/sections/StakePool.js
@@ -318,7 +318,7 @@ export default function StakePool(props) {
         </Grid>
         <Grid item xs={12} sm={4}>
           <Typography className={classes.title}>{formatApy(poolData[index].apy)}</Typography>
-          <Typography className={classes.subtitle}>{t('Vault-APY')}</Typography>
+          <Typography className={classes.subtitle}>{t('Vault-APR')}</Typography>
         </Grid>
 
         {pools[index].status === 'closed' || pools[index].status === 'soon' ? (

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -4,6 +4,7 @@
   "Vault-Wallet": "Wallet",
   "Vault-ConnectWallet": "Connect Wallet",
   "Vault-Balance": "Balance",
+  "Vault-APR": "APR",
   "Vault-APY": "APY",
   "Vault-APYDaily": "Daily",
   "Vault-TVL": "TVL",


### PR DESCRIPTION
As mentioned at #feedback, the returns in boosted vaults shouldn't be displayed as APY, since it's actually APR.