### PR TITLE
fix: Aligning Beefy to Beefy.Finance and MDex to Mdex across pools files

### DIFF
--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -18,7 +18,7 @@ export const bscPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
-    platform: 'Beefy',
+    platform: 'Beefy.Finance',
     assets: ['BIFI'],
     callFee: 0.5,
     buyTokenUrl: 'https://app.1inch.io/#/56/swap/BNB/BIFI',

--- a/src/features/configure/vault/heco_pools.js
+++ b/src/features/configure/vault/heco_pools.js
@@ -18,6 +18,7 @@ export const hecoPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Beefy.Finance',
     assets: ['BIFI'],
     callFee: 0.05,
     buyTokenUrl:
@@ -28,7 +29,7 @@ export const hecoPools = [
     logo: 'single-assets/MDX.png',
     name: 'MDX',
     token: 'MDX',
-    tokenDescription: 'MDex',
+    tokenDescription: 'Mdex',
     tokenAddress: '0x25D2e80cB6B86881Fd7e07dd263Fb79f4AbE033c',
     tokenDecimals: 18,
     tokenDescriptionUrl: '#',

--- a/src/features/configure/vault/polygon_pools.js
+++ b/src/features/configure/vault/polygon_pools.js
@@ -18,6 +18,7 @@ export const polygonPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
+    platform: 'Beefy.Finance',
     assets: ['BIFI'],
     callFee: 0.05,
     buyTokenUrl:


### PR DESCRIPTION
Picked up work to aggregate vaults and platforms across all (5 at time of writing) networks that Beefy supports.

In doing so noticed that Beefy vaults have platform referring to Beefy in one file and Beefy.Finance in others.

MDex is referred to as MDex and Mdex in different places inside the heco pools file. 

Also added platform key within all Beefy related vaults for good metadata down the line.

This PR is a simple patch.