### PR TITLE
Fixes for vault details page

### DIFF
--- a/src/features/vault/components/PoolDetails/PoolDetails.js
+++ b/src/features/vault/components/PoolDetails/PoolDetails.js
@@ -160,7 +160,6 @@ const PoolDetails = ({ vaultId }) => {
       </Helmet>
       <HomeLink />
       <div className={classes.container}>
-        <h1 className={classes.heading}>{t('Vault-Details')}</h1>
         {vaultStateTitle}
         <Grid className={classes.summary} container justify="space-around" xs={12} spacing={0}>
           <PoolTitle

--- a/src/features/vault/components/PoolSummary/PoolTitle/PoolTitle.js
+++ b/src/features/vault/components/PoolSummary/PoolTitle/PoolTitle.js
@@ -32,9 +32,11 @@ const PoolTitle = ({
       />
       <div className={classes.texts}>
         <Typography className={classes.title} variant="body2" gutterBottom>
-          <a href={`/vault/${poolId}`} className={classes.url}>
-            {name}
-          </a>
+          {poolId ? (
+            <a href={`/vault/${poolId}`} className={classes.url}>
+              {name}
+            </a>
+          ) : name}
         </Typography>
         <Typography className={classes.subtitle} variant="body2">
           {description}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -54,7 +54,6 @@
   "Vault-Experimental": "Testweise",
   "Vault-Loading": "Vault wird geladen",
   "Vault-NotFound": "Vault {{vaultId}} nicht gefunden",
-  "Vault-Details": "Vault Details",
   "Vaults-Back": "Zurück zu Vaults",
   "Hide-Zero-Balances": "Nullsalden ausblenden",
   "Hide-Zero-Vault-Balances": "Eingezahlte Vaults",

--- a/src/locales/el/translation.json
+++ b/src/locales/el/translation.json
@@ -54,7 +54,6 @@
   "Vault-Experimental": "Πειραματικά",
   "Vault-Loading": "Φόρτωση χρηματοκιβώτιου",
   "Vault-NotFound": "Το χρηματοκιβώτιο {{vaultId}} δεν βρέθηκε",
-  "Vault-Details": "Πληροφορίες Χρηματοκιβώτιου",
   "Vaults-Back": "Πίσω στα Χρηματοκιβώτια",
   "Hide-Zero-Balances": "Απόκρυψη μηδενικών υπολοίπων",
   "Hide-Zero-Vault-Balances": "Χρηματοκιβώτια με καταθέσεις",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -56,7 +56,6 @@
   "Vault-Experimental": "Experimental",
   "Vault-Loading": "Loading Vault",
   "Vault-NotFound": "Vault {{vaultId}} not found",
-  "Vault-Details": "Vault Details",
   "Vaults-Back": "Back to vaults",
   "Hide-Zero-Balances": "Hide Zero Balances",
   "Hide-Zero-Vault-Balances": "Deposited Vaults",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -54,7 +54,6 @@
   "Vault-Experimental": "Experimental",
   "Vault-Loading": "Cargando bóveda",
   "Vault-NotFound": "Bóveda {{vaultId}} no encontrada",
-  "Vault-Details": "Detalles de la bóveda",
   "Vaults-Back": "Volver a bóvedas",
   "Hide-Zero-Balances": "Ocultar saldos en cero",
   "Hide-Zero-Vault-Balances": "Bóvedas Depositadas",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -54,7 +54,6 @@
   "Vault-Experimental": "Expérimental",
   "Vault-Loading": "Chargement du coffre",
   "Vault-NotFound": "Coffre {{vaultId}} introuvable",
-  "Vault-Details": "Détails du coffre",
   "Vaults-Back": "Retour aux coffres",
   "Hide-Zero-Balances": "Cacher les petits soldes",
   "Hide-Zero-Vault-Balances": "Coffres déposés",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -54,7 +54,6 @@
   "Vault-Experimental": "Sperimentale",
   "Vault-Loading": "Caricamento cassaforte...",
   "Vault-NotFound": "Cassaforte {{vaultId}} non trovata",
-  "Vault-Details": "Dettagli cassaforte",
   "Vaults-Back": "Torna alle casseforti",
   "Hide-Zero-Balances": "Nascondi saldi nulli",
   "Hide-Zero-Vault-Balances": "Casseforti con deposito",

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -54,7 +54,6 @@
   "Vault-Experimental": "Experimenteel",
   "Vault-Loading": "Kluis laden",
   "Vault-NotFound": "Kluis {{vaultId}} niet gevonden",
-  "Vault-Details": "Kluis details",
   "Vaults-Back": "Terug naar de kluizen",
   "Hide-Zero-Balances": "Verberg nul saldo's",
   "Hide-Zero-Vault-Balances": "Gebruikt",

--- a/src/locales/pt/translation.json
+++ b/src/locales/pt/translation.json
@@ -42,7 +42,6 @@
   "Vault-Network": "Rede",
   "Vault-Loading": "Carregando Cofre",
   "Vault-NotFound": "Cofre {{vaultId}} não encontrado",
-  "Vault-Details": "Detalhes do Cofre",
   "Vaults-Back": "Voltar para cofres",
   "Hide-Zero-Balances": "Ocultar Ativos Com Saldo Zero",
   "Hide-Zero-Vault-Balances": "Cofres com Depósitos",


### PR DESCRIPTION
- Remove redundant h1 which pulling attention away from the vault itself
- Fix broken link

Before:
![Screenshot 2021-06-06 at 20 47 53](https://user-images.githubusercontent.com/2115473/120936669-4a4b1600-c709-11eb-8e03-4985e7dbcb0c.png)

After:
![Screenshot 2021-06-06 at 20 54 30](https://user-images.githubusercontent.com/2115473/120936689-664eb780-c709-11eb-92c1-41a9f25f7219.png)
