### PR TITLE
fixed ATA-BNB Uses: Platform

### DIFF
--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -108,7 +108,7 @@ export const bscPools = [
     logo: 'bnb-pairs/ATA-BNB.svg',
     name: 'ATA-BNB LP',
     token: 'ATA-BNB LP',
-    tokenDescription: 'Pancake',
+    tokenDescription: 'PancakeSwap',
     tokenAddress: '0xeF7767677867552CFA699148b96a03358A9be779',
     tokenDecimals: 18,
     tokenDescriptionUrl: '#',


### PR DESCRIPTION
tokenDescription was still Pancake instead of PancakeSwap