### PR TITLE
Update MAXI fees to 0.05% for Polygon

### DIFF
--- a/src/features/configure/vault/polygon_pools.js
+++ b/src/features/configure/vault/polygon_pools.js
@@ -21,6 +21,7 @@ export const polygonPools = [
     platform: 'Beefy.Finance',
     assets: ['BIFI'],
     callFee: 0.05,
+    withdrawalFee: '0.05%',
     buyTokenUrl:
       'https://quickswap.exchange/#/swap?inputCurrency=0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619&outputCurrency=0xfbdd194376de19a88118e84e279b977f165d01b8',
   },


### PR DESCRIPTION
the withdraw fees for the MAXI vaults on non BSC-maxis display 0.1% currently

so updating them to be 0.05% to be consistent with BSC maxi.