### PR TITLE
per chain nav buy link

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -11,7 +11,7 @@ import Menu from '@material-ui/icons/Menu';
 import Close from '@material-ui/icons/Close';
 import WbSunny from '@material-ui/icons/WbSunny';
 import NightsStay from '@material-ui/icons/NightsStay';
-
+import { getNetworkBuyLink } from '../../features/helpers/getNetworkData';
 import styles from './styles';
 
 const useStyles = makeStyles(styles);
@@ -134,9 +134,7 @@ const LinkSidebar = ({ name, label, icon, classes }) => (
 );
 
 const getLinkUrl = name => {
-  return name === 'buy'
-    ? 'https://1inch.exchange/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B/BNB/BIFI/?network=56'
-    : `https://${name}.beefy.finance`;
+  return name === 'buy' ? getNetworkBuyLink() : `https://${name}.beefy.finance`;
 };
 
 export default Header;

--- a/src/features/helpers/getNetworkData.js
+++ b/src/features/helpers/getNetworkData.js
@@ -41,6 +41,14 @@ const networkFriendlyName = {
   250: 'Fantom',
 };
 
+const networkBuyLinks = {
+  56: 'https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B',
+  128: 'https://ht.mdex.com/#/swap?inputCurrency=0xa71edc38d189767582c38a3145b5873052c3e47a&outputCurrency=0x765277eebeca2e31912c9946eae1021199b39c61',
+  137: 'https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B',
+  250: 'https://spookyswap.finance/swap?inputCurrency=0x04068da6c83afcfa0e13ba15a6696662335d5b75&outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
+  43114: 'https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B',
+};
+
 export const getNetworkCoin = () => {
   return nativeCoins.find(coin => coin.chainId == process.env.REACT_APP_NETWORK_ID);
 };
@@ -353,3 +361,4 @@ export const getNetworkConnectors = t => {
 
 export const getNetworkTxUrl = networkTxUrls[process.env.REACT_APP_NETWORK_ID];
 export const getNetworkFriendlyName = () => networkFriendlyName[process.env.REACT_APP_NETWORK_ID];
+export const getNetworkBuyLink = () => networkBuyLinks[process.env.REACT_APP_NETWORK_ID];


### PR DESCRIPTION
56 - BSC
https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B
Keeping the 1inch referral link: See discord discussion for more info.
Updated to new domain.
Currently there does not seem to be a way to provide deep links to chains/swaps on 1inch while retaining the referral code.

128 - HECO
https://ht.mdex.com/#/swap?inputCurrency=0xa71edc38d189767582c38a3145b5873052c3e47a&outputCurrency=0x765277eebeca2e31912c9946eae1021199b39c61
Buy on Mdex with Heco-Peg USDT

137 - Polygon
https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B
Keeping the 1inch referral link: As per BSC notes

250 - Fantom
https://spookyswap.finance/swap?inputCurrency=0x04068da6c83afcfa0e13ba15a6696662335d5b75&outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960
Buy on SpookySwap with USDC (this routes through FTM)

43114 - Avalanche
https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B
Keeping the 1inch referral link: Nowhere to buy BIFI on Avalanche