### PR TITLE
In-page network error display including chain name

### DIFF
--- a/src/common/networkSetup.js
+++ b/src/common/networkSetup.js
@@ -1,4 +1,4 @@
-const networkSettings = {
+export const networkSettings = {
   56: {
     chainId: `0x${parseInt(56, 10).toString(16)}`,
     chainName: 'BSC Mainnet',

--- a/src/components/NetworkError/NetworkError.js
+++ b/src/components/NetworkError/NetworkError.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+
+import { networkSettings } from 'common/networkSetup';
+
+import styles from './styles';
+
+const useStyles = makeStyles(styles);
+
+const NetworkError = ({ network }) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+
+  return (
+    <Grid container item className={classes.root} justify="center">
+      <Typography className={classes.networkError}>
+        {t('Network-Error', { network: networkSettings[network].chainName })}
+      </Typography>
+    </Grid>
+  );
+};
+
+export default NetworkError;

--- a/src/components/NetworkError/styles.js
+++ b/src/components/NetworkError/styles.js
@@ -1,0 +1,19 @@
+const styles = theme => ({
+  root: {
+    flexGrow: 1,
+    alignItems: 'center',
+  },
+  textCenter: {
+    textAlign: 'center',
+  },
+  networkError: {
+    padding: '12px',
+    borderRadius: '0',
+    background: theme.palette.background.secondary,
+    marginBottom: '2rem',
+    fontWeight: 900,
+    color: theme.palette.text.primary,
+  },
+});
+
+export default styles;

--- a/src/features/home/App.js
+++ b/src/features/home/App.js
@@ -6,6 +6,7 @@ import Header from 'components/Header/Header';
 import HeaderLinks from 'components/HeaderLinks/HeaderLinks';
 import NetworksProvider from 'components/NetworksProvider/NetworksProvider';
 import NetworksModal from 'components/NetworksModal/NetworksModal';
+import NetworkError from 'components/NetworkError/NetworkError';
 
 import { useTranslation } from 'react-i18next';
 
@@ -31,6 +32,7 @@ export default function App({ children }) {
     useConnectWallet();
   const { disconnectWallet } = useDisconnectWallet();
   const [web3Modal, setModal] = useState(null);
+  const [networkError, setNetworkError] = useState(null);
 
   const { isNightMode, setNightMode } = useNightMode();
   const theme = createTheme(isNightMode);
@@ -53,10 +55,7 @@ export default function App({ children }) {
       networkId &&
       Boolean(networkId !== Number(process.env.REACT_APP_NETWORK_ID))
     ) {
-      networkSetup(process.env.REACT_APP_NETWORK_ID).catch(e => {
-        console.error(e);
-        alert(t('Network-Error'));
-      });
+      networkSetup(process.env.REACT_APP_NETWORK_ID).catch(setNetworkError);
     }
   }, [web3, address, networkId, connectWalletPending, t]);
 
@@ -86,6 +85,7 @@ export default function App({ children }) {
               />
               <div className={classes.container}>
                 <div className={classes.children}>
+                  {networkError && <NetworkError network={process.env.REACT_APP_NETWORK_ID} />}
                   {Boolean(networkId === Number(process.env.REACT_APP_NETWORK_ID)) && children}
                   <Notifier />
                 </div>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,7 +1,7 @@
 {
   "App-Meta-Description": "The Multichain Yield Optimizer",
   "Disclaimer": "Using Smart Contracts, Tokens, and Crypto is always a risk. DYOR before investing.",
-  "Network-Error": "Connect to the correct network please.",
+  "Network-Error": "Connect to {{network}} please.",
   "Vault-Wallet": "Wallet",
   "Vault-ConnectWallet": "Connect Wallet",
   "Vault-Balance": "Balance",


### PR DESCRIPTION
Took a stab at fixing #548. 

When MetaMask is connected to the wrong network, instead of a JavaScript `alert()` popup, the app will now show in in-page error message including the network name that the user is supposed to connect to.

<img width="285" alt="Screen Shot 2021-06-15 at 7 35 39 AM" src="https://user-images.githubusercontent.com/749244/122072289-4aec4800-cdac-11eb-9df7-67a59aa8cb6e.png">

Needs updated translation files to support other languages. 