### PR TITLE
Tooltips + Vault stats row tidy

### DIFF
--- a/src/features/vault/components/PoolDetails/styles.js
+++ b/src/features/vault/components/PoolDetails/styles.js
@@ -56,6 +56,10 @@ const styles = theme => ({
       flexBasis: '50%',
       maxWidth: '50%',
     },
+    [theme.breakpoints.up('md')]: {
+      flexBasis: '37%',
+      maxWidth: '37%',
+    },
     [theme.breakpoints.up('lg')]: {
       flexBasis: '30%',
       maxWidth: '30%',
@@ -66,15 +70,23 @@ const styles = theme => ({
       flexBasis: '25%',
       maxWidth: '25%',
     },
+    [theme.breakpoints.up('md')]: {
+      flexBasis: '15%',
+      maxWidth: '15%',
+    },
     [theme.breakpoints.up('lg')]: {
-      flexBasis: '14%',
-      maxWidth: '14%',
+      flexBasis: '18%',
+      maxWidth: '18%',
     },
   },
   itemStats: {
+    [theme.breakpoints.up('md')]: {
+      flexBasis: '11%',
+      maxWidth: '11%',
+    },
     [theme.breakpoints.up('lg')]: {
-      flexBasis: '14%',
-      maxWidth: '14%',
+      flexBasis: '11.33%',
+      maxWidth: '11.33%',
     },
   },
   itemInner: {

--- a/src/features/vault/components/PoolSummary/ApyStats/ApyStats.js
+++ b/src/features/vault/components/PoolSummary/ApyStats/ApyStats.js
@@ -124,18 +124,20 @@ const ApyStats = ({ apy, launchpool, isLoading = false, itemClasses, itemInnerCl
   const { t } = useTranslation();
   const isBoosted = launchpool !== undefined;
   const values = {};
-  let needsTooltip = false;
+  let needsApyTooltip = false;
+  let needsDailyTooltip = false;
 
   values.totalApy = apy.totalApy;
 
   if ('vaultApr' in apy && apy.vaultApr) {
-    needsTooltip = true;
+    needsApyTooltip = true;
     values.vaultApr = apy.vaultApr;
     values.vaultDaily = apy.vaultApr / 365;
   }
 
   if ('tradingApr' in apy && apy.tradingApr) {
-    needsTooltip = true;
+    needsApyTooltip = true;
+    needsDailyTooltip = true;
     values.tradingApr = apy.tradingApr;
     values.tradingDaily = apy.tradingApr / 365;
   }
@@ -147,7 +149,8 @@ const ApyStats = ({ apy, launchpool, isLoading = false, itemClasses, itemInnerCl
   }
 
   if (isBoosted) {
-    needsTooltip = needsTooltip || !!launchpool.apy;
+    needsApyTooltip = needsApyTooltip || !!launchpool.apy;
+    needsDailyTooltip = needsDailyTooltip || !!launchpool.apy;
     values.boostApr = launchpool.apy;
     values.boostDaily = launchpool.apy / 365;
     values.boostedTotalApy = values.boostApr ? values.totalApy + values.boostApr : 0;
@@ -164,7 +167,9 @@ const ApyStats = ({ apy, launchpool, isLoading = false, itemClasses, itemInnerCl
         <LabeledStatWithTooltip
           value={formatted.totalApy}
           label={t('Vault-APY')}
-          tooltip={!isLoading && needsTooltip ? <YearlyBreakdownTooltip rates={formatted} /> : null}
+          tooltip={
+            !isLoading && needsApyTooltip ? <YearlyBreakdownTooltip rates={formatted} /> : null
+          }
           boosted={isBoosted ? formatted.boostedTotalApy : ''}
           isLoading={isLoading}
           className={`tooltip-toggle ${itemInnerClasses}`}
@@ -174,7 +179,9 @@ const ApyStats = ({ apy, launchpool, isLoading = false, itemClasses, itemInnerCl
         <LabeledStatWithTooltip
           value={formatted.totalDaily}
           label={t('Vault-APYDaily')}
-          tooltip={!isLoading && needsTooltip ? <DailyBreakdownTooltip rates={formatted} /> : null}
+          tooltip={
+            !isLoading && needsDailyTooltip ? <DailyBreakdownTooltip rates={formatted} /> : null
+          }
           boosted={isBoosted ? formatted.boostedTotalDaily : ''}
           isLoading={isLoading}
           className={`tooltip-toggle ${itemInnerClasses}`}

--- a/src/features/vault/components/PoolSummary/styles.js
+++ b/src/features/vault/components/PoolSummary/styles.js
@@ -32,6 +32,10 @@ const styles = theme => ({
       flexBasis: '50%',
       maxWidth: '50%',
     },
+    [theme.breakpoints.up('md')]: {
+      flexBasis: '37%',
+      maxWidth: '37%',
+    },
     [theme.breakpoints.up('lg')]: {
       flexBasis: '30%',
       maxWidth: '30%',
@@ -42,15 +46,23 @@ const styles = theme => ({
       flexBasis: '25%',
       maxWidth: '25%',
     },
+    [theme.breakpoints.up('md')]: {
+      flexBasis: '15%',
+      maxWidth: '15%',
+    },
     [theme.breakpoints.up('lg')]: {
-      flexBasis: '14%',
-      maxWidth: '14%',
+      flexBasis: '18%',
+      maxWidth: '18%',
     },
   },
   itemStats: {
+    [theme.breakpoints.up('md')]: {
+      flexBasis: '11%',
+      maxWidth: '11%',
+    },
     [theme.breakpoints.up('lg')]: {
-      flexBasis: '14%',
-      maxWidth: '14%',
+      flexBasis: '11.33%',
+      maxWidth: '11.33%',
     },
   },
   itemInner: {


### PR DESCRIPTION
**Tooltips:**
Only show the Daily tooltip if there is a Trading % or Boost % to show.

Before:
![image](https://user-images.githubusercontent.com/55021052/122969664-cc337400-d384-11eb-8824-e5e4c07021b7.png)

After:
![image](https://user-images.githubusercontent.com/55021052/122969700-d81f3600-d384-11eb-810a-6d1ac969eea6.png)

**Vault stats row at 960px**
Fit on to one line.

Before:
![image](https://user-images.githubusercontent.com/55021052/122969890-19afe100-d385-11eb-9a72-9b175cc4cbe9.png)

After:
![image](https://user-images.githubusercontent.com/55021052/122969941-26343980-d385-11eb-8b4a-e146009d463e.png)


