### PR TITLE
show boost APR/Daily on single vault page

### DIFF
--- a/src/features/stake/route.js
+++ b/src/features/stake/route.js
@@ -4,6 +4,6 @@ export default {
   path: 'stake',
   childRoutes: [
     { path: 'stake', component: StakePage, isIndex: true },
-    { path: 'pool/:index', component: PoolPage },
+    { path: 'pool/:id', component: PoolPage },
   ],
 };

--- a/src/features/stake/sections/StakePool.js
+++ b/src/features/stake/sections/StakePool.js
@@ -56,7 +56,7 @@ export default function StakePool(props) {
   const { fetchClaim, fetchClaimPending } = useFetchClaim();
   const { fetchExit, fetchExitPending } = useFetchExit();
   const { pools, poolData, fetchPoolData } = useFetchPoolData();
-  const [index, setIndex] = useState(Number(props.match.params.index) - 1);
+  const [index, setIndex] = useState(pools.findIndex(p => p.id === props.match.params.id));
   const [showInput, setShowInput] = useState(false);
   const [isNeedApproval, setIsNeedApproval] = useState(true);
   const [approvalAble, setApprovalAble] = useState(true);
@@ -95,8 +95,8 @@ export default function StakePool(props) {
   };
 
   useEffect(() => {
-    setIndex(Number(props.match.params.index) - 1);
-  }, [Number(props.match.params.index)]);
+    setIndex(pools.findIndex(p => p.id === props.match.params.id));
+  }, [props.match.params.id, pools]);
 
   useEffect(() => {
     setIsNeedApproval(Boolean(allowance[index] === 0));

--- a/src/features/stake/sections/StakePools.js
+++ b/src/features/stake/sections/StakePools.js
@@ -153,7 +153,7 @@ export default function StakePools(props) {
                     xs={5}
                     md={2}
                     className={classes.stakeBtn}
-                    href={`/stake/pool/${index + 1}`}
+                    href={`/stake/pool/${pool.id}`}
                   >
                     {pools[index].status === 'closed'
                       ? t('Stake-Button-Claim')

--- a/src/features/vault/components/Pool/Pool.js
+++ b/src/features/vault/components/Pool/Pool.js
@@ -26,20 +26,14 @@ const Pool = ({
 
   const [isOpen, setIsOpen] = useState(false);
   const toggleCard = useCallback(() => setIsOpen(!isOpen), [isOpen]);
+  const timestamp = Math.floor(Date.now() / 1000);
   const stake = useSelector(state => state.stake.pools);
+  const launchpool = stake.find(p => {
+    return p.token === pool.earnedToken && p.periodFinish >= timestamp;
+  });
 
   let balanceSingle = byDecimals(tokens[pool.token].tokenBalance, pool.tokenDecimals);
   let sharesBalance = new BigNumber(tokens[pool.earnedToken].tokenBalance);
-
-  const checkLaunchpool = () => {
-    const timestamp = Math.floor(Date.now() / 1000);
-    for (let index in stake) {
-      if (stake[index].token === pool.earnedToken && stake[index].periodFinish >= timestamp) {
-        stake[index].poolIndex = Number(index) + 1;
-        return stake[index];
-      }
-    }
-  };
 
   return (
     <Grid item xs={12} container key={index} className={classes.container} spacing={0}>
@@ -51,7 +45,7 @@ const Pool = ({
       >
         <PoolSummary
           pool={pool}
-          launchpool={checkLaunchpool()}
+          launchpool={launchpool}
           balanceSingle={balanceSingle}
           toggleCard={toggleCard}
           sharesBalance={sharesBalance}

--- a/src/features/vault/components/PoolSummary/ApyStats/ApyStats.js
+++ b/src/features/vault/components/PoolSummary/ApyStats/ApyStats.js
@@ -120,9 +120,9 @@ const LabeledStatWithTooltip = memo(({ tooltip, label, ...passthrough }) => {
   );
 });
 
-const ApyStats = ({ apy, launchpool, isLoading = false, itemClasses, itemInnerClasses }) => {
+const ApyStats = ({ apy, launchpoolApr, isLoading = false, itemClasses, itemInnerClasses }) => {
   const { t } = useTranslation();
-  const isBoosted = launchpool !== undefined;
+  const isBoosted = !!launchpoolApr;
   const values = {};
   let needsApyTooltip = false;
   let needsDailyTooltip = false;
@@ -149,10 +149,10 @@ const ApyStats = ({ apy, launchpool, isLoading = false, itemClasses, itemInnerCl
   }
 
   if (isBoosted) {
-    needsApyTooltip = needsApyTooltip || !!launchpool.apy;
-    needsDailyTooltip = needsDailyTooltip || !!launchpool.apy;
-    values.boostApr = launchpool.apy;
-    values.boostDaily = launchpool.apy / 365;
+    needsApyTooltip = true;
+    needsDailyTooltip = true;
+    values.boostApr = launchpoolApr;
+    values.boostDaily = launchpoolApr / 365;
     values.boostedTotalApy = values.boostApr ? values.totalApy + values.boostApr : 0;
     values.boostedTotalDaily = values.boostDaily ? values.totalDaily + values.boostDaily : 0;
   }

--- a/src/features/vault/components/PoolSummary/PoolSummary.js
+++ b/src/features/vault/components/PoolSummary/PoolSummary.js
@@ -120,7 +120,7 @@ const PoolSummary = ({
         </Grid>
         <ApyStats
           apy={apy}
-          launchpool={launchpool}
+          launchpoolApr={launchpool && launchpool.apy ? launchpool.apy : null}
           isLoading={!fetchApysDone}
           itemClasses={`${classes.item} ${classes.itemStats}`}
           itemInnerClasses={classes.itemInner}

--- a/src/features/vault/components/PoolSummary/PoolTitle/PoolTitle.js
+++ b/src/features/vault/components/PoolSummary/PoolTitle/PoolTitle.js
@@ -117,7 +117,7 @@ const PoolTitle = ({
           )}
         </div>
         {launchpool ? (
-          <a className={classes.btnBoost} href={'/stake/pool/' + launchpool.poolIndex}>
+          <a className={classes.btnBoost} href={'/stake/pool/' + launchpool.id}>
             <img alt="Boost" src={require('images/stake/boost.svg')} height={15} />
             <span>
               <img alt="Fire" src={require('images/stake/fire.png')} height={30} />


### PR DESCRIPTION
Fixes #489
Fetch the launchpool data on the single vault page and don't memoize it (state update currently adds `apy` etc keys to existing object)

**Refactors launchpool urls** from `/stake/pool/{array index + 1}`  to `/stake/pool/{pool.id}` 
e.g. `/stake/pool/moo_merlin-merlin` instead of `/stake/pool/2`
This saves modifying the stake pools array to add the `poolIndex` key.