### PR TITLE
Update addLiquidityUrl for Ellipsis

### DIFF
--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -7469,7 +7469,7 @@ export const bscPools = [
     platform: 'Ellipsis',
     assets: ['renBTC', 'BTCB'],
     callFee: 0.5,
-    addLiquidityUrl: 'https://ellipsis.finance/ren/deposit',
+    addLiquidityUrl: 'https://ellipsis.finance/pool',
   },
   {
     id: 'ellipsis-fusdt-3eps',
@@ -7493,7 +7493,7 @@ export const bscPools = [
     platform: 'Ellipsis',
     assets: ['fUSDT', 'USDT', 'BUSD', 'USDC'],
     callFee: 0.5,
-    addLiquidityUrl: 'https://ellipsis.finance/fusdt/deposit',
+    addLiquidityUrl: 'https://ellipsis.finance/pool',
   },
 
   {
@@ -8721,7 +8721,7 @@ export const bscPools = [
     platform: 'Ellipsis',
     assets: ['USDT', 'BUSD', 'USDC', '3EPS'],
     callFee: 0.5,
-    addLiquidityUrl: 'https://ellipsis.finance/3pool/deposit',
+    addLiquidityUrl: 'https://ellipsis.finance/pool',
     buyTokenUrl:
       'https://exchange.pancakeswap.finance/#/swap?outputCurrency=0xe9e7cea3dedca5984780bafc599bd69add087d56',
   },


### PR DESCRIPTION
To https://ellipsis.finance/pool

Does not seem to be a deep link direct to relevant pool anymore