### PR TITLE
Show full USD balance on vault page (without units)

### DIFF
--- a/src/features/helpers/format.js
+++ b/src/features/helpers/format.js
@@ -14,13 +14,13 @@ export const formatApy = apy => {
   return `${num.toFixed(2)}${units[order]}%`;
 };
 
-export const formatTvl = (tvl, oraclePrice) => {
+export const formatTvl = (tvl, oraclePrice, useOrder = true) => {
   if (oraclePrice) {
     tvl = BigNumber(tvl).times(oraclePrice).toFixed(2);
   }
 
   let order = Math.floor(Math.log10(tvl) / 3);
-  if (order < 0) {
+  if (order < 0 || useOrder === false) {
     order = 0;
   }
 

--- a/src/features/vault/components/PoolDetails/PoolDetails.js
+++ b/src/features/vault/components/PoolDetails/PoolDetails.js
@@ -104,7 +104,7 @@ const PoolDetails = ({ vaultId }) => {
     pool.tokenDecimals
   );
   const depositedUsd =
-    deposited > 0 && fetchVaultsDataDone ? formatTvl(deposited, pool.oraclePrice) : '';
+    deposited > 0 && fetchVaultsDataDone ? formatTvl(deposited, pool.oraclePrice, false) : '';
 
   if (!fetchVaultsDataDone) {
     return (


### PR DESCRIPTION
User request to be able to see full USD balance, i think showing in PoolDetails (vault page) is a good solution to this