### PR TITLE
Only call periodFinish on active launchpools

### DIFF
--- a/src/features/stake/sections/StakePools.js
+++ b/src/features/stake/sections/StakePools.js
@@ -31,9 +31,13 @@ export default function StakePools(props) {
 
   useEffect(() => {
     const fetchEndPeriod = () => {
-      for (const key in pools) {
-        if (halfTime[key] === undefined || halfTime[key] === 0) {
-          fetchHalfTime(key);
+      for (const index in Object.keys(pools)) {
+        if (
+          pools[index].hideCountdown !== true &&
+          pools[index].status !== 'closed' &&
+          !halfTime[index]
+        ) {
+          fetchHalfTime(index);
         }
       }
     };


### PR DESCRIPTION
On launchpools page (/stake):
Only call `fetchHalfTime`/`periodFinish` for launchpools that do not have a status of `'closed'` and do not have `hideCountdown` set to `true`. i.e. only active/pending pools, excluding maxi.

Reduces RPC calls by 1 + number of inactive pools.

(This was low hanging fruit, multicall would be better going forward).