### PR TITLE
Hide buttons that require web3 to create txs if no wallet is connected

### DIFF
--- a/src/components/NetworkRequired/NetworkRequired.js
+++ b/src/components/NetworkRequired/NetworkRequired.js
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next';
+import { useConnectWallet } from '../../features/home/redux/connectWallet';
+import { getNetworkFriendlyName } from '../../features/helpers/getNetworkData';
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import styles from './styles';
+import classnames from 'classnames';
+
+const useStyles = makeStyles(styles);
+
+export function NetworkRequired({ children, inline = false }) {
+  const { t } = useTranslation();
+  const { web3, address } = useConnectWallet();
+  const classes = useStyles();
+  const targetNetworkFriendlyName = getNetworkFriendlyName();
+
+  if (!web3 || !address) {
+    return (
+      <div
+        className={classnames({
+          [classes.common]: true,
+          [classes.inline]: inline,
+          [classes.contained]: !inline,
+        })}
+      >
+        {t('Network-ConnectionRequired', { network: targetNetworkFriendlyName })}
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/src/components/NetworkRequired/NetworkRequired.js
+++ b/src/components/NetworkRequired/NetworkRequired.js
@@ -5,16 +5,21 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import styles from './styles';
 import classnames from 'classnames';
+import ValueLoader from '../../features/common/components/ValueLoader/ValueLoader';
 
 const useStyles = makeStyles(styles);
 
-export function NetworkRequired({ children, inline = false }) {
+export function NetworkRequired({ children, inline = false, loader = false }) {
   const { t } = useTranslation();
   const { web3, address } = useConnectWallet();
   const classes = useStyles();
   const targetNetworkFriendlyName = getNetworkFriendlyName();
 
   if (!web3 || !address) {
+    if (loader) {
+      return <ValueLoader />;
+    }
+
     return (
       <div
         className={classnames({

--- a/src/components/NetworkRequired/styles.js
+++ b/src/components/NetworkRequired/styles.js
@@ -1,0 +1,25 @@
+const styles = theme => ({
+  common: {
+    padding: 20,
+    color: theme.palette.primary.main,
+    textAlign: 'center',
+    width: '100%',
+    '& > :last-child': {
+      marginBottom: 0,
+    },
+  },
+  contained: {
+    backgroundColor: theme.palette.background.primary,
+    border: `1px solid ${theme.palette.background.border}`,
+    borderRadius: '8px',
+    marginBottom: 25,
+    color: theme.palette.primary.main,
+    width: '100%',
+    '& > :last-child': {
+      marginBottom: 0,
+    },
+  },
+  inline: {},
+});
+
+export default styles;

--- a/src/features/stake/sections/StakePool.js
+++ b/src/features/stake/sections/StakePool.js
@@ -44,6 +44,7 @@ import { launchpools } from '../../helpers/getNetworkData';
 import { useSelector } from 'react-redux';
 import { StakeCountdown } from './StakeCountdown';
 import ValueLoader from '../../common/components/ValueLoader/ValueLoader';
+import { NetworkRequired } from '../../../components/NetworkRequired/NetworkRequired';
 
 const useStyles = makeStyles(styles);
 
@@ -304,85 +305,87 @@ export default function StakePool(props) {
         )}
       </Grid>
 
-      <Grid container className={classes.row}>
-        {launchpool.partnership ? (
-          <Box className={classes.boosted}>{t('Stake-BoostedBy', { name: launchpool.name })}</Box>
-        ) : (
-          ''
-        )}
-        <Grid item xs={12} md={6} lg={3}>
-          {isNeedApproval ? (
+      <NetworkRequired>
+        <Grid container className={classes.row}>
+          {launchpool.partnership ? (
+            <Box className={classes.boosted}>{t('Stake-BoostedBy', { name: launchpool.name })}</Box>
+          ) : (
+            ''
+          )}
+          <Grid item xs={12} md={6} lg={3}>
+            {isNeedApproval ? (
+              <Button
+                className={classes.actionBtn}
+                disabled={fetchApprovalPending}
+                onClick={onApproval}
+              >
+                {t('Stake-Button-Approval')}
+              </Button>
+            ) : (
+              <Button
+                className={[classes.actionBtn, launchpool.partnership ? classes.btnBoost : ''].join(
+                  ' '
+                )}
+                disabled={fetchStakePending || userBalance.isZero()}
+                onClick={() => {
+                  handleModal(true, 'stake');
+                }}
+              >
+                {launchpool.partnership ? (
+                  <Box className={classes.boost}>
+                    <Box>
+                      <Avatar
+                        src={require('images/' + launchpool.logo)}
+                        alt={launchpool.token}
+                        variant="square"
+                        imgProps={{ style: { objectFit: 'contain' } }}
+                      />
+                    </Box>
+                    <Box>
+                      <img
+                        alt={t('Boost')}
+                        className={classes.boostImg}
+                        src={require('images/stake/boost.svg')}
+                      />
+                    </Box>
+                  </Box>
+                ) : (
+                  t('Stake-Button-Stake-Tokens')
+                )}
+              </Button>
+            )}
+          </Grid>
+          <Grid item xs={12} md={6} lg={3}>
             <Button
               className={classes.actionBtn}
-              disabled={fetchApprovalPending}
-              onClick={onApproval}
-            >
-              {t('Stake-Button-Approval')}
-            </Button>
-          ) : (
-            <Button
-              className={[classes.actionBtn, launchpool.partnership ? classes.btnBoost : ''].join(
-                ' '
-              )}
-              disabled={fetchStakePending || userBalance.isZero()}
+              disabled={fetchWithdrawPending || userStaked.isZero()}
               onClick={() => {
-                handleModal(true, 'stake');
+                handleModal(true, 'unstake');
               }}
             >
-              {launchpool.partnership ? (
-                <Box className={classes.boost}>
-                  <Box>
-                    <Avatar
-                      src={require('images/' + launchpool.logo)}
-                      alt={launchpool.token}
-                      variant="square"
-                      imgProps={{ style: { objectFit: 'contain' } }}
-                    />
-                  </Box>
-                  <Box>
-                    <img
-                      alt={t('Boost')}
-                      className={classes.boostImg}
-                      src={require('images/stake/boost.svg')}
-                    />
-                  </Box>
-                </Box>
-              ) : (
-                t('Stake-Button-Stake-Tokens')
-              )}
+              {t('Stake-Button-Unstake-Tokens')}
             </Button>
-          )}
+          </Grid>
+          <Grid item xs={12} md={6} lg={3}>
+            <Button
+              className={classes.actionBtn}
+              disabled={fetchClaimPending || userRewardsAvailable.isZero()}
+              onClick={onClaim}
+            >
+              {t('Stake-Button-Claim-Rewards')}
+            </Button>
+          </Grid>
+          <Grid item xs={12} md={6} lg={3}>
+            <Button
+              className={classes.actionBtn}
+              disabled={fetchExitPending || userStaked.isZero() || userRewardsAvailable.isZero()}
+              onClick={onExit}
+            >
+              {t('Stake-Button-Exit')}
+            </Button>
+          </Grid>
         </Grid>
-        <Grid item xs={12} md={6} lg={3}>
-          <Button
-            className={classes.actionBtn}
-            disabled={fetchWithdrawPending || userStaked.isZero()}
-            onClick={() => {
-              handleModal(true, 'unstake');
-            }}
-          >
-            {t('Stake-Button-Unstake-Tokens')}
-          </Button>
-        </Grid>
-        <Grid item xs={12} md={6} lg={3}>
-          <Button
-            className={classes.actionBtn}
-            disabled={fetchClaimPending || userRewardsAvailable.isZero()}
-            onClick={onClaim}
-          >
-            {t('Stake-Button-Claim-Rewards')}
-          </Button>
-        </Grid>
-        <Grid item xs={12} md={6} lg={3}>
-          <Button
-            className={classes.actionBtn}
-            disabled={fetchExitPending || userStaked.isZero() || userRewardsAvailable.isZero()}
-            onClick={onExit}
-          >
-            {t('Stake-Button-Exit')}
-          </Button>
-        </Grid>
-      </Grid>
+      </NetworkRequired>
 
       {launchpool.partners.map(partner => (
         <Grid

--- a/src/features/stake/sections/StakePool.js
+++ b/src/features/stake/sections/StakePool.js
@@ -250,17 +250,23 @@ export default function StakePool(props) {
           />
         </Grid>
         <Grid item xs={6} sm={6} md={3}>
-          <Typography className={classes.title}>{formatDecimals(userBalance)}</Typography>
+          <Typography className={classes.title}>
+            <NetworkRequired loader>{formatDecimals(userBalance)}</NetworkRequired>
+          </Typography>
           <Typography className={classes.tokenTitle}>{launchpool.token}</Typography>
           <Typography className={classes.subtitle}>{t('Vault-Wallet')}</Typography>
         </Grid>
         <Grid item xs={6} sm={6} md={3}>
-          <Typography className={classes.title}>{formatDecimals(userStaked)}</Typography>
+          <Typography className={classes.title}>
+            <NetworkRequired loader>{formatDecimals(userStaked)}</NetworkRequired>
+          </Typography>
           <Typography className={classes.tokenTitle}>{launchpool.token}</Typography>
           <Typography className={classes.subtitle}>{t('Stake-Balancer-Current-Staked')}</Typography>
         </Grid>
         <Grid item xs={6} sm={6} md={3}>
-          <Typography className={classes.title}>{formatDecimals(userRewardsAvailable)}</Typography>
+          <Typography className={classes.title}>
+            <NetworkRequired loader>{formatDecimals(userRewardsAvailable)}</NetworkRequired>
+          </Typography>
           <Typography className={classes.tokenTitle}>{launchpool.earnedToken}</Typography>
           <Typography className={classes.subtitle}>
             {t('Stake-Balancer-Rewards-Available')}
@@ -282,7 +288,9 @@ export default function StakePool(props) {
           </Typography>
         </Grid>
         <Grid item xs={12} sm={4}>
-          <Typography className={classes.title}>{formatPercent(myPoolShare, 4)}</Typography>
+          <Typography className={classes.title}>
+            <NetworkRequired loader>{formatPercent(myPoolShare, 4)}</NetworkRequired>
+          </Typography>
           <Typography className={classes.subtitle}>{t('Stake-Your-Pool')}%</Typography>
         </Grid>
         <Grid item xs={12} sm={4}>

--- a/src/features/vault/components/PoolActions/PoolActions.js
+++ b/src/features/vault/components/PoolActions/PoolActions.js
@@ -5,14 +5,17 @@ import DepositSection from '../PoolDetails/DepositSection/DepositSection';
 import WithdrawSection from '../PoolDetails/WithdrawSection/WithdrawSection';
 import HarvestSection from '../PoolDetails/HarvestSection/HarvestSection';
 import { shouldHideFromHarvest } from '../../../helpers/utils';
+import { NetworkRequired } from '../../../../components/NetworkRequired/NetworkRequired';
 
 const PoolActions = ({ pool, balanceSingle, index, sharesBalance }) => {
   return (
-    <Grid container>
-      <DepositSection index={index} pool={pool} balanceSingle={balanceSingle} />
-      <WithdrawSection index={index} pool={pool} sharesBalance={sharesBalance} />
-      {shouldHideFromHarvest(pool.id) ? '' : <HarvestSection index={index} pool={pool} />}
-    </Grid>
+    <NetworkRequired inline>
+      <Grid container>
+        <DepositSection index={index} pool={pool} balanceSingle={balanceSingle} />
+        <WithdrawSection index={index} pool={pool} sharesBalance={sharesBalance} />
+        {shouldHideFromHarvest(pool.id) ? '' : <HarvestSection index={index} pool={pool} />}
+      </Grid>
+    </NetworkRequired>
   );
 };
 

--- a/src/features/vault/components/PoolDetails/PoolDetails.js
+++ b/src/features/vault/components/PoolDetails/PoolDetails.js
@@ -21,9 +21,9 @@ import PoolPaused from '../PoolSummary/PoolPaused/PoolPaused';
 import { CakeV2Banner } from './Banners/CakeV2Banner/CakeV2Banner';
 import { launchpools } from '../../../helpers/getNetworkData';
 import {
-  usePoolApr,
   useLaunchpoolSubscriptions,
   useLaunchpoolUpdates,
+  usePoolApr,
 } from '../../../stake/redux/hooks';
 
 const FETCH_INTERVAL_MS = 30 * 1000;
@@ -59,17 +59,17 @@ const PoolDetails = ({ vaultId }) => {
   useLaunchpoolUpdates();
 
   useEffect(() => {
-    if (address && web3) {
-      const fetch = () => {
+    const fetch = () => {
+      if (address && web3) {
         fetchBalances({ address, web3, tokens });
-        fetchVaultsData({ address, web3, pools });
-        fetchApys();
-      };
-      fetch();
+      }
+      fetchVaultsData({ address, web3, pools });
+      fetchApys();
+    };
+    fetch();
 
-      const id = setInterval(fetch, FETCH_INTERVAL_MS);
-      return () => clearInterval(id);
-    }
+    const id = setInterval(fetch, FETCH_INTERVAL_MS);
+    return () => clearInterval(id);
 
     // Adding tokens and pools to this dep list, causes an endless loop, DDoSing the api
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,17 +115,7 @@ const PoolDetails = ({ vaultId }) => {
   const depositedUsd =
     deposited > 0 && fetchVaultsDataDone ? formatTvl(deposited, pool.oraclePrice, false) : '';
 
-  if (!fetchVaultsDataDone) {
-    return (
-      <>
-        <HomeLink />
-        {vaultId === 'cake-cakev2' ? <CakeV2Banner /> : ''}
-        <div className={classes.container}>
-          <div className={classes.loading}>{t('Vault-Loading')}</div>
-        </div>
-      </>
-    );
-  } else if (!pool) {
+  if (!pool) {
     return (
       <>
         <HomeLink />


### PR DESCRIPTION
**New component `NetworkRequired`**
If there is no wallet connected (no `web3` or `address` available), will show a message indicating a wallet connection is required.
Otherwise renders its children.
Defaults to returning a message in a box. (See bottom of boost)
Pass `inline` to return text only (See bottom of vault)
Pass `loader` to return a value loader instead (See values in boost)

Vault
![image](https://user-images.githubusercontent.com/55021052/125832171-d85bb64c-371f-4e69-a0c0-a2116cd2b315.png)

Boost
![image](https://user-images.githubusercontent.com/55021052/125831617-30ac8304-4ef7-48f6-855d-3d5aa92c2fc1.png)

