### PR TITLE
Fix: Wallet won't connect

### DIFF
--- a/src/features/web3/createWeb3Modal.js
+++ b/src/features/web3/createWeb3Modal.js
@@ -2,4 +2,13 @@ import Web3Modal from 'web3modal';
 
 import { getNetworkConnectors } from 'features/helpers/getNetworkData';
 
-export const createWeb3Modal = t => new Web3Modal(getNetworkConnectors(t));
+export const createWeb3Modal = t => {
+  const connectors = getNetworkConnectors(t);
+  const modal = new Web3Modal(connectors);
+
+  if (modal.cachedProvider && !(modal.cachedProvider in connectors.providerOptions)) {
+    modal.clearCachedProvider();
+  }
+
+  return modal;
+};


### PR DESCRIPTION
**Problem:**
Switching networks can leave you unable to connect your wallet: the wallet connect button won't do anything when clicked.

**To reproduce the problem (e.g. using MetaMask Desktop):**

1. Go to https://app.beefy.finance/#/bsc
2. Select 'SafePal' in the connect modal (this works even if you are not using SafePal, as both MetaMask and SafePal inject a wallet)
3. Switch to polygon at https://app.beefy.finance/#/polygon - you'll see this:
![image](https://user-images.githubusercontent.com/55021052/132729614-566b037d-dfce-4c4c-9a06-b169415a18c7.png)
4. Clicking 'Connect Wallet' won't do anything, as Web3Modal will try to connect via the cached provider (SafePal) which doesn't exist in the list of providers on the Polygon network; this fails silently.

**Fix:**
Upon modal creation (in `createWeb3Modal`), this fix checks if the cached provider exists in the list of providers for the current network, and clears the cached provider if it is not.

