### PR TITLE
Clear invalid platform/asset filter

### DIFF
--- a/src/components/Disclaimer/Disclaimer.js
+++ b/src/components/Disclaimer/Disclaimer.js
@@ -13,7 +13,7 @@ const Disclaimer = () => {
   const classes = useStyles();
 
   return (
-    <Grid container item className={classes.root} justify="center">
+    <Grid container item className={classes.root} justifyContent="center">
       <Typography className={classes.disclaimer}>{t('Disclaimer')}</Typography>
     </Grid>
   );

--- a/src/features/home/App.js
+++ b/src/features/home/App.js
@@ -14,12 +14,12 @@ import appStyle from './jss/appStyle.js';
 import { createWeb3Modal } from '../web3';
 import { useConnectWallet, useDisconnectWallet } from './redux/hooks';
 import useNightMode from './hooks/useNightMode';
-import createTheme from './jss/appTheme';
+import createThemeMode from './jss/appTheme';
 import { useLocation } from 'react-router';
 
 const themes = { light: null, dark: null };
 const getTheme = mode => {
-  return (themes[mode] = themes[mode] || createTheme(mode === 'dark'));
+  return (themes[mode] = themes[mode] || createThemeMode(mode === 'dark'));
 };
 
 const ScrollToTop = memo(function () {

--- a/src/features/home/jss/appTheme.js
+++ b/src/features/home/jss/appTheme.js
@@ -1,7 +1,7 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-const createTheme = isNightMode =>
-  createMuiTheme({
+const createThemeMode = isNightMode =>
+  createTheme({
     palette: {
       type: isNightMode ? 'dark' : 'light',
       background: {
@@ -51,4 +51,4 @@ const createTheme = isNightMode =>
     },
   });
 
-export default createTheme;
+export default createThemeMode;

--- a/src/features/vault/components/Filters/Filters.js
+++ b/src/features/vault/components/Filters/Filters.js
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useEffect, useMemo } from 'react';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import { makeStyles } from '@material-ui/core/styles';
@@ -60,6 +60,18 @@ const Filters = ({
     setAsset('All');
     setOrder('default');
   }, [toggleFilter, setPlatform, setVaultType, setAsset, setOrder]);
+
+  useEffect(() => {
+    if ((!asset || !allAssetOptions.find(option => option.value === asset)) && asset !== 'All') {
+      setAsset('All');
+    }
+  }, [asset, setAsset]);
+
+  useEffect(() => {
+    if ((!platform || !platforms.includes(platform)) && platform !== 'All') {
+      setPlatform('All');
+    }
+  }, [platform, setPlatform]);
 
   return (
     <Grid container spacing={2} className={classes.container}>


### PR DESCRIPTION
Since we are on one app/domain now; stored filter settings are shared across networks.
Not all platform/assets are available on all networks, causing non-existing items to be selected in the filters.
e.g. Select DOGE as asset on BSC and switch to Fantom - it will show no vaults and a blank asset filter.

This PR resets the platform/asset filters to All if an unavailable option is selected.

(Also fixed: Deprecated use of `createMuiTheme`, and `justify="center"`)