### PR TITLE
Update getNetworkData.js to use polygon-rpc.com

### DIFF
--- a/src/features/helpers/getNetworkData.js
+++ b/src/features/helpers/getNetworkData.js
@@ -463,8 +463,8 @@ export const getNetworkConnectors = t => {
             options: {
               network: 'matic',
               rpc: {
-                1: 'https://rpc-mainnet.maticvigil.com/',
-                137: 'https://rpc-mainnet.maticvigil.com/',
+                1: 'https://polygon-rpc.com/',
+                137: 'https://polygon-rpc.com/',
               },
             },
           },


### PR DESCRIPTION
Currently, walletconnect with polygon uses maticvigil which throws CORS errors. This change changes the walletconnect polygon rpc to `polygon-rpc.com` which supports CORS properly (with the added benefit of being an aggregator). This only affects connections through walletconnect. 

![image](https://user-images.githubusercontent.com/775255/139561960-6f68cf18-822b-4985-bbf7-8da24042db30.png)

More info on the polygon-rpc: https://blog.polygon.technology/polygon-rpc-gateway-will-provide-a-free-high-performance-connection-to-the-polygon-pos-blockchain/