### PR TITLE
Updating the walletconnect matic rpc to use polygon-rpc.com

### DIFF
--- a/src/features/helpers/getNetworkData.js
+++ b/src/features/helpers/getNetworkData.js
@@ -463,8 +463,8 @@ export const getNetworkConnectors = t => {
             options: {
               network: 'matic',
               rpc: {
-                1: 'https://rpc-mainnet.maticvigil.com/',
-                137: 'https://rpc-mainnet.maticvigil.com/',
+                1: 'https://polygon-rpc.com',
+                137: 'https://polygon-rpc.com',
               },
             },
           },


### PR DESCRIPTION
Currently, walletconnect with polygon uses maticvigil which throws CORS errors. This change flips it to polygon-rpc.com which is a better aggregator anyway. This only affects connections through walletconnect.