### PR TITLE
EOL 30 vaults

### DIFF
--- a/src/features/configure/vault/avalanche_pools.js
+++ b/src/features/configure/vault/avalanche_pools.js
@@ -1345,7 +1345,7 @@ export const avalanchePools = [
     buyTokenUrl: 'https://www.traderjoexyz.com/#/trade',
   },
   {
-    id: 'joe-usdt.e-dai.e',
+    id: 'joe-usdt.e-dai.e-eol',
     name: 'USDT.e-DAI.e LP',
     token: 'USDT.e-DAI.e JLP',
     tokenDescription: 'Trader Joe',
@@ -1360,8 +1360,8 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'joe-usdt.e-dai.e',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Trader Joe',
     assets: ['USDTe', 'DAIe'],
     risks: [
@@ -1373,6 +1373,7 @@ export const avalanchePools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://www.traderjoexyz.com/#/pool/0xc7198437980c041c805a1edcba50c1ce5db95118/0xd586e7f844cea2f87f50152665bcbc2c279d8d70',
     buyTokenUrl: 'https://www.traderjoexyz.com/#/trade',
@@ -1545,7 +1546,7 @@ export const avalanchePools = [
     buyTokenUrl: 'https://www.traderjoexyz.com/#/trade',
   },
   {
-    id: 'pangolin-png',
+    id: 'pangolin-png-pause',
     logo: 'single-assets/PNG.svg',
     name: 'PNG',
     token: 'PNG',
@@ -1561,7 +1562,7 @@ export const avalanchePools = [
     oracle: 'tokens',
     oracleId: 'PNG',
     oraclePrice: 0,
-    depositsPaused: false,
+    depositsPaused: true,
     status: 'active',
     platform: 'Pangolin',
     assets: ['PNG'],
@@ -1977,7 +1978,7 @@ export const avalanchePools = [
     buyTokenUrl: 'https://www.traderjoexyz.com/#/trade',
   },
   {
-    id: 'pangolin-usdc.e-wavax',
+    id: 'pangolin-usdc.e-wavax-pause',
     name: 'USDC.e-AVAX LP',
     token: 'USDC.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2075,7 +2076,7 @@ export const avalanchePools = [
       'https://swap.olive.cash/#/add/0x19860CCB0A68fd4213aB9D8266F7bBf05A8dDe98/0xc7198437980c041c805A1EDcbA50c1Ce5db95118',
   },
   {
-    id: 'pangolin-png-qi',
+    id: 'pangolin-png-qi-pause',
     name: 'QI-PNG LP',
     token: 'QI-PNG LP',
     tokenDescription: 'Pangolin',
@@ -2109,7 +2110,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x8729438EB15e2C8B576fCc6AeCdA6A148776C0F5',
   },
   {
-    id: 'pangolin-qi-wavax',
+    id: 'pangolin-qi-wavax-pause',
     name: 'QI-AVAX LP',
     token: 'QI-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2143,7 +2144,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x8729438EB15e2C8B576fCc6AeCdA6A148776C0F5',
   },
   {
-    id: 'pangolin-uni.e-wavax',
+    id: 'pangolin-uni.e-wavax-pause',
     name: 'UNI.e-AVAX LP',
     token: 'UNI.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2177,7 +2178,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x8eBAf22B6F053dFFeaf46f4Dd9eFA95D89ba8580',
   },
   {
-    id: 'pangolin-yfi.e-wavax',
+    id: 'pangolin-yfi.e-wavax-pause',
     name: 'YFI.e-AVAX LP',
     token: 'YFI.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2211,7 +2212,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x9eAaC1B23d935365bD7b542Fe22cEEe2922f52dc',
   },
   {
-    id: 'pangolin-aave.e-wavax',
+    id: 'pangolin-aave.e-wavax-pause',
     name: 'AAVE.e-AVAX LP',
     token: 'AAVE.e-AVAXLP',
     tokenDescription: 'Pangolin',
@@ -2245,7 +2246,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x63a72806098Bd3D9520cC43356dD78afe5D386D9',
   },
   {
-    id: 'pangolin-sushi.e-wavax',
+    id: 'pangolin-sushi.e-wavax-pause',
     name: 'SUSHI.e-AVAX LP',
     token: 'SUSHI.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2279,7 +2280,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x37B608519F91f70F2EeB0e5Ed9AF4061722e4F76',
   },
   {
-    id: 'pangolin-wavax-xava',
+    id: 'pangolin-wavax-xava-pause',
     name: 'XAVA-AVAX LP',
     token: 'XAVA-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2313,7 +2314,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x5947BB275c521040051D82396192181b413227A3',
   },
   {
-    id: 'pangolin-png-usdt.e',
+    id: 'pangolin-png-usdt.e-pause',
     name: 'USDT.e-PNG LP',
     token: 'USDT.e-PNG LP',
     tokenDescription: 'Pangolin',
@@ -2347,7 +2348,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0xc7198437980c041c805A1EDcbA50c1Ce5db95118',
   },
   {
-    id: 'pangolin-weth.e-png',
+    id: 'pangolin-weth.e-png-pause',
     name: 'WETH.e-PNG LP',
     token: 'WETH.e-PNG LP',
     tokenDescription: 'Pangolin',
@@ -2381,7 +2382,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0xc7198437980c041c805A1EDcbA50c1Ce5db95118',
   },
   {
-    id: 'pangolin-wavax-dai.e',
+    id: 'pangolin-wavax-dai.e-pause',
     name: 'DAI.e-AVAX LP',
     token: 'DAI.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2415,7 +2416,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0xd586E7F844cEa2F87f50152665BCbc2C279D8d70',
   },
   {
-    id: 'pangolin-link.e-wavax',
+    id: 'pangolin-link.e-wavax-pause',
     name: 'LINK.e-AVAX LP',
     token: 'LINK.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2449,7 +2450,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0x5947BB275c521040051D82396192181b413227A3',
   },
   {
-    id: 'pangolin-weth.e-wavax',
+    id: 'pangolin-weth.e-wavax-pause',
     name: 'WETH.e-AVAX LP',
     token: 'WETH.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2483,7 +2484,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0xc7198437980c041c805A1EDcbA50c1Ce5db95118',
   },
   {
-    id: 'pangolin-wavax-usdt.e',
+    id: 'pangolin-wavax-usdt.e-pause',
     name: 'USDT.e-AVAX LP',
     token: 'USDT.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2517,7 +2518,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7&outputCurrency=0xc7198437980c041c805A1EDcbA50c1Ce5db95118',
   },
   {
-    id: 'pangolin-wbtc.e-wavax',
+    id: 'pangolin-wbtc.e-wavax-pause',
     name: 'WBTC.e-AVAX LP',
     token: 'WBTC.e-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2586,7 +2587,7 @@ export const avalanchePools = [
       'https://app.pangolin.exchange/#/swap?inputCurrency=0x60781c2586d68229fde47564546784ab3faca982&outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
   },
   {
-    id: 'png-bnb-avax',
+    id: 'png-bnb-avax-pause',
     name: 'BNB-AVAX LP',
     token: 'BNB-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -2867,7 +2868,7 @@ export const avalanchePools = [
   },
 
   {
-    id: 'com-com-avax',
+    id: 'com-com-avax-eol',
     logo: 'avax-pairs/COM-AVAX.png',
     name: 'COM-AVAX LP',
     token: 'COM-AVAX LP',
@@ -2883,10 +2884,11 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'com-com-avax',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Complus',
     assets: ['COM', 'AVAX'],
+    retireReason: 'tvl',
     addLiquidityUrl:
       'https://avadex.complus.exchange/#/add/AVAX/0x3711c397B6c8F7173391361e27e67d72F252cAad',
     buyTokenUrl:
@@ -3111,7 +3113,7 @@ export const avalanchePools = [
   },
 
   {
-    id: 'png-png-avax',
+    id: 'png-png-avax-pause',
     name: 'PNG-AVAX LP',
     token: 'PNG-AVAX LP',
     tokenDescription: 'Pangolin',

--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -529,7 +529,7 @@ export const bscPools = [
       'https://pancakeswap.finance/swap?outputCurrency=0x8F0528cE5eF7B51152A59745bEfDD91D97091d2F',
   },
   {
-    id: '1inch-1inch',
+    id: '1inch-1inch-eol',
     logo: 'single-assets/INCH.png',
     name: '1INCH',
     token: '1INCH',
@@ -545,8 +545,8 @@ export const bscPools = [
     oracle: 'tokens',
     oracleId: '1INCH',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: '1Inch',
     assets: ['1INCH'],
     risks: [
@@ -558,6 +558,7 @@ export const bscPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'SingleStake',
+    retireReason: 'rewards',
     buyTokenUrl:
       'https://1inch.exchange/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B/BNB/1INCH/?network=56',
   },
@@ -1003,7 +1004,7 @@ export const bscPools = [
       'https://dex.apeswap.finance/#/swap?outputCurrency=0x5774B2fc3e91aF89f89141EacF76545e74265982',
   },
   {
-    id: 'banana-exp-wbnb',
+    id: 'banana-exp-wbnb-eol',
     name: 'EXP-BNB LP',
     token: 'EXP-BNB BLP',
     tokenDescription: 'ApeSwap',
@@ -1019,7 +1020,7 @@ export const bscPools = [
     oracleId: 'banana-exp-wbnb',
     oraclePrice: 0,
     depositsPaused: true,
-    status: 'active',
+    status: 'eol',
     platform: 'ApeSwap',
     assets: ['EXP', 'BNB'],
     risks: [
@@ -1031,6 +1032,7 @@ export const bscPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://dex.apeswap.finance/#/add/ETH/0x639d4C62F58a4048AD0F69B8CE675dB1A3e8e00e',
     buyTokenUrl:
@@ -1989,7 +1991,7 @@ export const bscPools = [
     addLiquidityUrl: 'https://belt.fi/',
   },
   {
-    id: 'pearzap-pear-bnb',
+    id: 'pearzap-pear-bnb-eol',
     name: 'PEAR-BNB LP',
     token: 'PEAR-BNB LP',
     tokenDescription: 'ApeSwap (PearZap)',
@@ -2004,17 +2006,18 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'pearzap-pear-bnb',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['PEAR', 'BNB'],
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://app.apeswap.finance/add/ETH/0xdf7C18ED59EA738070E665Ac3F5c258dcc2FBad8',
     buyTokenUrl:
       'https://app.apeswap.finance/swap?outputCurrency=0xdf7C18ED59EA738070E665Ac3F5c258dcc2FBad8',
   },
   {
-    id: 'pearzap-pear-busd',
+    id: 'pearzap-pear-busd-eol',
     name: 'PEAR-BUSD LP',
     token: 'PEAR-BUSD LP',
     tokenDescription: 'ApeSwap (PearZap)',
@@ -2029,10 +2032,11 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'pearzap-pear-busd',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['PEAR', 'BUSD'],
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://app.apeswap.finance/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0xdf7C18ED59EA738070E665Ac3F5c258dcc2FBad8',
     buyTokenUrl:
@@ -2360,7 +2364,7 @@ export const bscPools = [
       'https://exchange.pancakeswap.finance/#/swap?inputCurrency=0x55d398326f99059fF775485246999027B3197955&outputCurrency=0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c',
   },
   {
-    id: 'mdex-bsc-rabbit-busd',
+    id: 'mdex-bsc-rabbit-busd-eol',
     name: 'RABBIT-BUSD LP',
     token: 'RABBIT-BUSD LP',
     tokenDescription: 'Mdex',
@@ -2375,10 +2379,11 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'mdex-rabbit-busd',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Mdex',
     assets: ['RABBIT', 'BUSD'],
+    retireReason: 'tvl',
     addLiquidityUrl:
       'https://exchange.pancakeswap.finance/#/add/0x95a1199EBA84ac5f19546519e287d43D2F0E1b41/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
     buyTokenUrl:
@@ -4129,7 +4134,7 @@ export const bscPools = [
     addLiquidityUrl: 'https://ellipsis.finance/pool',
   },
   {
-    id: 'fruit-fruit-cake',
+    id: 'fruit-fruit-cake-eol',
     name: 'FRUIT-CAKE LP',
     token: 'FRUIT-CAKE LP',
     tokenDescription: 'ApeSwap (Fruit)',
@@ -4144,17 +4149,18 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'fruit-fruit-cake',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['FRUIT', 'CAKE'],
+    retireReason: 'tvl',
     addLiquidityUrl:
       'https://dex.apeswap.finance/#/add/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82/0x4ECfb95896660aa7F54003e967E7b283441a2b0A',
     buyTokenUrl:
       'https://dex.apeswap.finance/#/swap?outputCurrency=0x4ECfb95896660aa7F54003e967E7b283441a2b0A',
   },
   {
-    id: 'fruit-fruit-xvs',
+    id: 'fruit-fruit-xvs-eol',
     name: 'FRUIT-XVS LP',
     token: 'FRUIT-XVS LP',
     tokenDescription: 'ApeSwap (Fruit)',
@@ -4169,17 +4175,18 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'fruit-fruit-xvs',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['FRUIT', 'XVS'],
+    retireReason: 'tvl',
     addLiquidityUrl:
       'https://dex.apeswap.finance/#/add/0xcf6bb5389c92bdda8a3747ddb454cb7a64626c63/0x4ECfb95896660aa7F54003e967E7b283441a2b0A',
     buyTokenUrl:
       'https://dex.apeswap.finance/#/swap?outputCurrency=0x4ECfb95896660aa7F54003e967E7b283441a2b0A',
   },
   {
-    id: 'banana-fruit-bnb',
+    id: 'banana-fruit-bnb-eol',
     name: 'FRUIT-BNB LP',
     token: 'FRUIT-BNB LP',
     tokenDescription: 'ApeSwap',
@@ -4194,17 +4201,18 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'banana-fruit-bnb',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'ApeSwap',
     assets: ['FRUIT', 'BNB'],
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://dex.apeswap.finance/#/add/ETH/0x4ECfb95896660aa7F54003e967E7b283441a2b0A',
     buyTokenUrl:
       'https://dex.apeswap.finance/#/swap?outputCurrency=0x4ECfb95896660aa7F54003e967E7b283441a2b0A',
   },
   {
-    id: 'stablequant-quant-busd',
+    id: 'stablequant-quant-busd-eol',
     logo: 'degens/quant-busd.png',
     name: 'QUANT-BUSD LP',
     token: 'QUANT-BUSD LP',
@@ -4221,9 +4229,10 @@ export const bscPools = [
     oracleId: 'stablequant-quant-busd',
     oraclePrice: 0,
     depositsPaused: true,
-    status: 'active',
+    status: 'eol',
     platform: 'Other',
     assets: ['QUANT', 'BUSD'],
+    retireReason: 'tvl',
     addLiquidityUrl:
       'https://pancakeswap.finance/add/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56/0xBCA627FEd3b6E8F414C745E12B2b89371497779D',
     buyTokenUrl:
@@ -4482,7 +4491,7 @@ export const bscPools = [
       'https://pancakeswap.finance/swap?inputCurrency=0x2eD9a5C8C13b93955103B9a7C167B67Ef4d568a3&outputCurrency=0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
   },
   {
-    id: 'ellipsis-pbtc',
+    id: 'ellipsis-pbtc-eol',
     logo: 'uncategorized/epsPBTC.png',
     name: 'pBTC/renBTC/BTCB',
     token: 'pbtcEPS',
@@ -4499,9 +4508,10 @@ export const bscPools = [
     oracleId: 'ellipsis-pbtc',
     oraclePrice: 0,
     depositsPaused: true,
-    status: 'active',
+    status: 'eol',
     platform: 'Ellipsis',
     assets: ['pBTC', 'renBTC', 'BTCB'],
+    retireReason: 'exploit',
     addLiquidityUrl: 'https://ellipsis.finance/pool',
   },
   {
@@ -7700,9 +7710,10 @@ export const bscPools = [
     oracleId: 'TOFY',
     oraclePrice: 0,
     depositsPaused: true,
-    status: 'active',
+    status: 'eol',
     platform: 'Other',
     assets: ['TOFY'],
+    retireReason: 'rewards',
     buyTokenUrl:
       'https://exchange.marshmallowdefi.com/#/swap?outputCurrency=0xE1F2d89a6c79b4242F300f880e490A70083E9A1c',
   },
@@ -13061,7 +13072,7 @@ export const bscPools = [
   },
 
   {
-    id: 'com-com-bnb',
+    id: 'com-com-bnb-eol',
     logo: 'bnb-pairs/COM-BNB.png',
     name: 'COM-BNB LP',
     token: 'COM-BNB LP',
@@ -13077,10 +13088,11 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'com-com-bnb',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['COM', 'BNB'],
+    retireReason: 'tvl',
     addLiquidityUrl:
       'https://bscdex.complus.exchange/#/add/BNB/0x7fa892544D49598460B821De4D99E8c28b1Decaa',
     buyTokenUrl:
@@ -14435,7 +14447,7 @@ export const bscPools = [
       'https://pancakeswap.finance/swap?inputCurrency=0xc2e1acef50ae55661855e8dcb72adb182a3cc259&outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },
   {
-    id: 'cake-btd-busd',
+    id: 'cake-btd-busd-eol',
     logo: 'single-assets/BTD.png',
     name: 'BTD-BUSD LP',
     token: 'BTD-BUSD LP',
@@ -14451,10 +14463,11 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'cake-btd-busd',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['BTD', 'BUSD'],
+    retireReason: 'tvl',
     buyTokenUrl:
       'https://pancakeswap.finance/swap?inputCurrency=0xD1102332a213E21faF78B69C03572031F3552c33&outputCurrency=0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
   },

--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -873,7 +873,7 @@ export const fantomPools = [
       'https://app.beethovenx.io/#/pool/0x2975035545008935152fdf48ca13406cc5d4e47500010000000000000000002a',
   },
   {
-    id: 'pearzap-fpear-ftm',
+    id: 'pearzap-fpear-ftm-eol',
     name: 'PEAR-FTM LP',
     token: 'PEAR-FTM LP',
     tokenDescription: 'SpiritSwap (PearZap)',
@@ -888,8 +888,8 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'pearzap-fpear-ftm',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['PEAR', 'FTM'],
     risks: [
@@ -901,13 +901,14 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://swap.spiritswap.finance/#/add/FTM/0x7C10108d4B7f4bd659ee57A53b30dF928244b354',
     buyTokenUrl:
       'https://swap.spiritswap.finance/#/swap/0x7c10108d4b7f4bd659ee57a53b30df928244b354',
   },
   {
-    id: 'pearzap-fpear-usdc',
+    id: 'pearzap-fpear-usdc-eol',
     name: 'PEAR-USDC LP',
     token: 'PEAR-USDC LP',
     tokenDescription: 'SpiritSwap (PearZap)',
@@ -922,8 +923,8 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'pearzap-fpear-usdc',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Other',
     assets: ['PEAR', 'USDC'],
     risks: [
@@ -935,6 +936,7 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://swap.spiritswap.finance/#/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0x7C10108d4B7f4bd659ee57A53b30dF928244b354',
     buyTokenUrl:
@@ -2247,7 +2249,7 @@ export const fantomPools = [
     buyTokenUrl: 'https://spookyswap.finance/swap',
   },
   {
-    id: 'boo-wftm-shade',
+    id: 'boo-wftm-shade-eol',
     name: 'SHADE-FTM LP',
     token: 'SHADE-FTM LP',
     tokenDescription: 'SpookySwap',
@@ -2262,8 +2264,8 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'boo-wftm-shade',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'SpookySwap',
     assets: ['SHADE', 'FTM'],
     risks: [
@@ -2276,6 +2278,7 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://spookyswap.finance/add/0x3A3841f5fa9f2c283EA567d5Aeea3Af022dD2262/FTM',
     buyTokenUrl: 'https://spookyswap.finance/swap',
@@ -2413,7 +2416,7 @@ export const fantomPools = [
     buyTokenUrl: 'https://spookyswap.finance/swap',
   },
   {
-    id: 'stakesteak-fusd-usdc',
+    id: 'stakesteak-fusd-usdc-eol',
     name: 'fUSD-USDC sAMM LP',
     token: 'fUSD-USDC sAMM LP',
     tokenDescription: 'StakeSteak',
@@ -2429,7 +2432,7 @@ export const fantomPools = [
     oracleId: 'stakesteak-fusd-usdc',
     oraclePrice: 0,
     depositsPaused: true,
-    status: 'active',
+    status: 'eol',
     platform: 'StakeSteak',
     assets: ['fUSD', 'USDC'],
     risks: [
@@ -2444,11 +2447,12 @@ export const fantomPools = [
     depositFee: '0.5%',
     withdrawalFee: '0%',
     addLiquidityUrl: 'https://stakesteak.app/',
+    retireReason: 'tvl',
     buyTokenUrl:
       'https://spookyswap.finance/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xAd84341756Bf337f5a0164515b1f6F993D194E1f',
   },
   {
-    id: 'boo-steak-wftm',
+    id: 'boo-steak-wftm-eol',
     name: 'STEAK-FTM LP',
     token: 'STEAK-FTM LP',
     tokenDescription: 'SpookySwap',
@@ -2464,7 +2468,7 @@ export const fantomPools = [
     oracleId: 'boo-steak-wftm',
     oraclePrice: 0,
     depositsPaused: true,
-    status: 'active',
+    status: 'eol',
     platform: 'SpookySwap',
     assets: ['STEAK', 'FTM'],
     risks: [
@@ -2477,6 +2481,7 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://spookyswap.finance/add/0x05848B832E872d9eDd84AC5718D58f21fD9c9649/FTM',
     buyTokenUrl: 'https://spookyswap.finance/swap',
@@ -2902,7 +2907,7 @@ export const fantomPools = [
     addLiquidityUrl: 'https://ftm.curve.fi/2pool/deposit',
   },
   {
-    id: 'curve-ftm-fusdt',
+    id: 'curve-ftm-fusdt-eol',
     logo: 'single-assets/USDT.svg',
     name: 'fUSDT/DAI/USDC',
     token: 'fusdtCRV',
@@ -2918,8 +2923,8 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'curve-ftm-fusdt',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'Curve',
     assets: ['fUSDT', 'USDC', 'DAI'],
     risks: [
@@ -2932,6 +2937,7 @@ export const fantomPools = [
     ],
     stratType: 'StratMultiLP',
     withdrawalFee: '0.01%',
+    retireReason: 'rewards',
     addLiquidityUrl: 'https://ftm.curve.fi/fusdt/deposit',
   },
   {
@@ -3298,7 +3304,7 @@ export const fantomPools = [
       'https://swap.spiritswap.finance/#/swap?outputCurrency=0x181f3f22c9a751e2ce673498a03e1fdfc0ebbfb6',
   },
   {
-    id: 'boo-woofy-ftm',
+    id: 'boo-woofy-ftm-eol',
     logo: 'fantom/WOOFY-FTM.png',
     name: 'WOOFY-FTM LP',
     token: 'WOOFY-FTM LP',
@@ -3314,8 +3320,8 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'boo-woofy-ftm',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'SpookySwap',
     assets: ['WOOFY', 'FTM'],
     risks: [
@@ -3327,6 +3333,7 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl: 'https://spookyswap.finance/add',
     buyTokenUrl: 'https://spookyswap.finance/swap',
   },
@@ -3488,7 +3495,7 @@ export const fantomPools = [
     buyTokenUrl: 'https://spookyswap.finance/swap',
   },
   {
-    id: 'boo-cream-ftm',
+    id: 'boo-cream-ftm-eol',
     logo: 'fantom/CREAM-FTM.png',
     name: 'CREAM-FTM LP',
     token: 'CREAM-FTM LP',
@@ -3504,8 +3511,8 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'boo-cream-ftm',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'SpookySwap',
     assets: ['CREAM', 'FTM'],
     risks: [
@@ -3517,6 +3524,7 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl: 'https://spookyswap.finance/add',
     buyTokenUrl: 'https://spookyswap.finance/swap',
   },

--- a/src/features/configure/vault/moonriver_pools.js
+++ b/src/features/configure/vault/moonriver_pools.js
@@ -1205,7 +1205,7 @@ export const moonriverPools = [
       'https://app.solarbeam.io/exchange/add/0xB44a9B6905aF7c801311e8F4E76932ee959c663C/0xE3F5a90F9cb311505cd691a46596599aA1A0AD7D',
   },
   {
-    id: 'solarbeam-mimatic-usdc',
+    id: 'solarbeam-mimatic-usdc-eol',
     name: 'MAI-USDC',
     token: 'MAI-USDC LP',
     tokenDescription: 'SolarBeam',
@@ -1220,8 +1220,8 @@ export const moonriverPools = [
     oracle: 'lps',
     oracleId: 'solarbeam-mimatic-usdc',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'SolarBeam',
     assets: ['MAI', 'USDC'],
     risks: [
@@ -1234,6 +1234,7 @@ export const moonriverPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
+    retireReason: 'rewards',
     buyTokenUrl:
       'https://app.solarbeam.io/exchange/swap?inputCurrency=0x7f5a79576620C046a293F54FFCdbd8f2468174F1&outputCurrency=0xE3F5a90F9cb311505cd691a46596599aA1A0AD7D',
     addLiquidityUrl:
@@ -1485,7 +1486,7 @@ export const moonriverPools = [
       'https://app.solarbeam.io/exchange/add/ETH/0x1e0F2A75Be02c025Bd84177765F89200c04337Da',
   },
   {
-    id: 'solarbeam-solar-rib',
+    id: 'solarbeam-solar-rib-eol',
     name: 'RIB-SOLAR',
     token: 'RIB-SOLAR LP',
     tokenDescription: 'SolarBeam',
@@ -1500,8 +1501,8 @@ export const moonriverPools = [
     oracle: 'lps',
     oracleId: 'solarbeam-solar-rib',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'SolarBeam',
     assets: ['RIB', 'SOLAR'],
     risks: [
@@ -1514,6 +1515,7 @@ export const moonriverPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
+    retireReason: 'rewards',
     buyTokenUrl:
       'https://app.solarbeam.io/exchange/swap?inputCurrency=0x6bD193Ee6D2104F14F94E2cA6efefae561A4334B&outputCurrency=0xbD90A6125a84E5C512129D622a75CDDE176aDE5E',
     addLiquidityUrl:

--- a/src/features/configure/vault/polygon_pools.js
+++ b/src/features/configure/vault/polygon_pools.js
@@ -243,7 +243,7 @@ export const polygonPools = [
       'https://quickswap.exchange/#/swap?outputCurrency=0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec&inputCurrency=0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',
   },
   {
-    id: 'quick-dpi-eth',
+    id: 'quick-dpi-eth-eol',
     name: 'DPI-ETH LP',
     token: 'DPI-ETH LP',
     tokenDescription: 'QuickSwap',
@@ -257,8 +257,8 @@ export const polygonPools = [
     tvl: 0,
     oracle: 'lps',
     oracleId: 'quick-dpi-eth',
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'QuickSwap',
     assets: ['DPI', 'ETH'],
     risks: [
@@ -272,6 +272,7 @@ export const polygonPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://quickswap.exchange/#/add/0x7ceb23fd6bc0add59e62ac25578270cff1b9f619/0x85955046DF4668e1DD369D2DE9f3AEB98DD2A369',
     buyTokenUrl:
@@ -1888,7 +1889,7 @@ export const polygonPools = [
       'https://quickswap.exchange/#/swap?outputCurrency=0x7DfF46370e9eA5f0Bad3C4E29711aD50062EA7A4',
   },
   {
-    id: 'quick-uni-eth',
+    id: 'quick-uni-eth-eol',
     name: 'UNI-ETH LP',
     token: 'UNI-ETH LP',
     tokenDescription: 'QuickSwap',
@@ -1903,8 +1904,8 @@ export const polygonPools = [
     oracle: 'lps',
     oracleId: 'quick-uni-eth',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'QuickSwap',
     assets: ['UNI', 'ETH'],
     risks: [
@@ -1917,6 +1918,7 @@ export const polygonPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://quickswap.exchange/#/add/0xb33EaAd8d922B1083446DC23f610c2567fB5180f/0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
     buyTokenUrl:
@@ -2665,7 +2667,7 @@ export const polygonPools = [
       'https://quickswap.exchange/#/swap?inputCurrency=0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270&outputCurrency=0xd0f3121A190d85dE0AB6131f2bCEcdbfcfB38891',
   },
   {
-    id: 'quick-nexo-eth',
+    id: 'quick-nexo-eth-eol',
     name: 'NEXO-ETH LP',
     token: 'NEXO-ETH LP',
     tokenDescription: 'Quickswap',
@@ -2680,8 +2682,8 @@ export const polygonPools = [
     oracle: 'lps',
     oracleId: 'quick-nexo-eth',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'QuickSwap',
     assets: ['NEXO', 'ETH'],
     risks: [
@@ -2694,6 +2696,7 @@ export const polygonPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://quickswap.exchange/#/add/0x7ceb23fd6bc0add59e62ac25578270cff1b9f619/0x41b3966B4FF7b427969ddf5da3627d6AEAE9a48E',
     buyTokenUrl:
@@ -5077,7 +5080,7 @@ export const polygonPools = [
       'https://app.sushi.com/#/swap?inputCurrency=0x5fe2B58c013d7601147DcdD68C143A77499f5531&outputCurrency=0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
   },
   {
-    id: 'sushi-frax-fxs',
+    id: 'sushi-frax-fxs-eol',
     logo: 'polygon/FRAX-FXS.png',
     name: 'FRAX-FXS SLP',
     token: 'FRAX-FXS SLP',
@@ -5093,8 +5096,8 @@ export const polygonPools = [
     oracle: 'lps',
     oracleId: 'sushi-frax-fxs',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'SushiSwap',
     assets: ['FRAX', 'FXS'],
     risks: [
@@ -5108,13 +5111,14 @@ export const polygonPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0.01%',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://app.sushi.com/add/0x104592a158490a9228070E0A8e5343B499e125D0/0x3e121107F6F22DA4911079845a470757aF4e1A1b',
     buyTokenUrl:
       'https://app.sushi.com/#/swap?inputCurrency=0x104592a158490a9228070E0A8e5343B499e125D0&outputCurrency=0x3e121107F6F22DA4911079845a470757aF4e1A1b',
   },
   {
-    id: 'sushi-frax-usdc',
+    id: 'sushi-frax-usdc-eol',
     logo: 'polygon/FRAX-USDC.png',
     name: 'FRAX-USDC SLP',
     token: 'FRAX-USDC SLP',
@@ -5130,8 +5134,8 @@ export const polygonPools = [
     oracle: 'lps',
     oracleId: 'sushi-frax-usdc',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
     platform: 'SushiSwap',
     assets: ['FRAX', 'USDC'],
     risks: [
@@ -5144,6 +5148,7 @@ export const polygonPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
+    retireReason: 'rewards',
     addLiquidityUrl:
       'https://app.sushi.com/add/0x104592a158490a9228070E0A8e5343B499e125D0/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
     buyTokenUrl:


### PR DESCRIPTION
PNG single is now paused in UI and all Pangolin vaults have the suffix -pause so the APYs are not displayed.

*AVAX*
Joe USDT.e-DAI.e
Complus COM-AVAX

*BSC* 
1inch
ApeSwap EXP-BNB
ApeSwap PEAR-BNB
ApeSwap PEAR-BUSD
Mdex RABBIT-BUSD
ApeSwap FRUIT-CAKE
ApeSwap FRUIT-XVS
ApeSwap FRUIT-BNB
StableQuant QUANT-BUSD
Ellipsis pBTC/renBTC/BTCB
TOFY
Complus COM-BNB
Pancake BTD-BUSD

*FTM*
Spirit PEAR-FTM
Spirit PEAR-USDC
Spooky SHADE-FTM
StakeSteak fUSD-USDC sAMM
Spooky STEAK-FTM
Curve fUSDT/DAI/USDC
Spooky WOOFY-FTM
Spooky CREAM-FTM

*MR*
Solar MAI-USDC
Solar RIB-SOLAR

*POLY*
Quick DPI-ETH
Quick UNI-ETH
Quick NEXO-ETH
Sushi FRAX-FXS
Sushi FRAX-USDC