### PR TITLE
Retire Spirit ZOO-WFTM & SPELL-fUSDT

### DIFF
--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -2991,7 +2991,7 @@ export const fantomPools = [
       'https://spookyswap.finance/swap?outputCurrency=0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
   },
   {
-    id: 'spirit-ftm-just',
+    id: 'spirit-ftm-just-eol',
     name: 'JUST-FTM LP',
     token: 'JUST-FTM SLP',
     tokenDescription: 'SpiritSwap',
@@ -3006,8 +3006,9 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'spirit-ftm-just',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'tvl',
     platform: 'SpiritSwap',
     assets: ['JUST', 'FTM'],
     risks: [

--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -3062,7 +3062,7 @@ export const fantomPools = [
       'https://swap.spiritswap.finance/#/exchange/swap/0xae75A438b2E0cB8Bb01Ec1E1e376De11D44477CC',
   },
   {
-    id: 'spirit-fusdt-spell',
+    id: 'spirit-fusdt-spell-eol',
     name: 'SPELL-fUSDT LP',
     token: 'SPELL-fUSDT SLP',
     tokenDescription: 'SpiritSwap',
@@ -3077,8 +3077,9 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'spirit-fusdt-spell',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'SpiritSwap',
     assets: ['SPELL', 'fUSDT'],
     risks: [

--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -2621,7 +2621,7 @@ export const fantomPools = [
       'https://swap.spiritswap.finance/#/exchange/swap/0x1E4F97b9f9F913c46F1632781732927B9019C68b',
   },
   {
-    id: 'spirit-zoo-ftm',
+    id: 'spirit-zoo-ftm-eol',
     name: 'ZOO-FTM LP',
     token: 'ZOO-FTM SLP',
     tokenDescription: 'SpiritSwap',
@@ -2636,8 +2636,9 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'spirit-zoo-ftm',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'tvl',
     platform: 'SpiritSwap',
     assets: ['ZOO', 'FTM'],
     risks: [
@@ -2991,7 +2992,7 @@ export const fantomPools = [
       'https://spookyswap.finance/swap?outputCurrency=0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
   },
   {
-    id: 'spirit-ftm-just-eol',
+    id: 'spirit-ftm-just',
     name: 'JUST-FTM LP',
     token: 'JUST-FTM SLP',
     tokenDescription: 'SpiritSwap',
@@ -3006,9 +3007,8 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'spirit-ftm-just',
     oraclePrice: 0,
-    depositsPaused: true,
-    status: 'eol',
-    retireReason: 'tvl',
+    depositsPaused: false,
+    status: 'active',
     platform: 'SpiritSwap',
     assets: ['JUST', 'FTM'],
     risks: [


### PR DESCRIPTION
Retire two spirit vaults.

ZOO vault has really low TVL (21K) and is a 0 decimal token, so it can create difficulties when harvesting.
SPELL-fUSDT ended rewards.