### PR TITLE
updating stables to use correct chain id

### DIFF
--- a/src/features/helpers/getNetworkData.js
+++ b/src/features/helpers/getNetworkData.js
@@ -455,7 +455,7 @@ export const getNetworkStables = () => {
       return ['fUSD', 'BUSD', 'USDC'];
     case 1088:
       return ['mUSDT', 'mUSDC'];
-    case 1088:
+    case 1284:
       return ['USDC', 'USDT', 'DAI', 'BUSD'];
     default:
       return [];


### PR DESCRIPTION
1088 was listed twice in the switch statement for stable list. I believe the latter of the two should be 1284, for the new moonbeam addition. 