### PR TITLE
Sync action after push to prod

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,0 +1,17 @@
+name: Sync CI
+
+on: 
+  push:
+    branches: 
+      - 'prod'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: seguido/beefy-app-sync@v0.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.SYNC_GITHUB_TOKEN }}
+          GITHUB_USER: 'chebiN'
+          GITHUB_EMAIL: 'chebiN@beefy.com'


### PR DESCRIPTION
After pushes to prod:
- trigger a sync between v1's prod branch and v2's master branch
- sync vaults
- sync assets
- sync addressbook
- push changes to v2 for merging