### PR TITLE
Fix duplicate vault ids

### DIFF
--- a/scripts/validatePools.js
+++ b/scripts/validatePools.js
@@ -50,10 +50,11 @@ const validatePools = async () => {
 
   let updates = {};
 
+  const uniquePoolId = new Set();
+
   for (let [chain, pools] of Object.entries(chainPools)) {
     console.log(`Validating ${pools.length} pools in ${chain}...`);
 
-    const uniquePoolId = new Set();
     const uniqueEarnedToken = new Set();
     const uniqueEarnedTokenAddress = new Set();
     const uniqueOracleId = new Set();

--- a/src/features/configure/vault/polygon_pools.js
+++ b/src/features/configure/vault/polygon_pools.js
@@ -7486,7 +7486,7 @@ export const polygonPools = [
     createdAt: 1620418656,
   },
   {
-    id: 'sushi-eth-dai',
+    id: 'polygon-sushi-eth-dai',
     logo: 'polygon/ETH-DAI.png',
     name: 'ETH-DAI LP',
     token: 'ETH-DAI SLP',
@@ -7523,7 +7523,7 @@ export const polygonPools = [
     createdAt: 1620653470,
   },
   {
-    id: 'sushi-btc-eth',
+    id: 'polygon-sushi-btc-eth',
     logo: 'polygon/ETH-BTC.png',
     name: 'WBTC-ETH LP',
     token: 'WBTC-ETH SLP',


### PR DESCRIPTION
- Validation script now verifies that pool ids are globally unique, not just on a single chain

- Fixed duplicate vault ids.

PR should be merged **AFTER** https://github.com/beefyfinance/beefy-api/pull/708 gets merged so that modified vaults are able to retrieve their apy values correctly.