### PR TITLE
EOL FIRE-AVAX + Set deposit fee for sJOE + streamline Tomb namings

### DIFF
--- a/src/features/configure/vault/avalanche_pools.js
+++ b/src/features/configure/vault/avalanche_pools.js
@@ -274,6 +274,7 @@ export const avalanchePools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'SingleStake',
+    depositFee: '1%',
     buyTokenUrl:
       'https://traderjoexyz.com/trade?outputCurrency=0x6e84a6216eA6dACC71eE8E6b0a5B7322EEbC0fDd',
     createdAt: 1631011023,
@@ -806,7 +807,7 @@ export const avalanchePools = [
     createdAt: 1645972427,
   },
   {
-    id: 'png-fire-wavax',
+    id: 'png-fire-wavax-eol',
     name: 'FIRE-AVAX LP',
     token: 'FIRE-AVAX LP',
     tokenDescription: 'Pangolin',
@@ -821,8 +822,9 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'png-fire-wavax',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Pangolin',
     assets: ['FIRE', 'AVAX'],
     risks: [

--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -109,7 +109,7 @@ export const fantomPools = [
     id: 'tomb-tshare-mai',
     name: 'TSHARE-MAI LP',
     token: 'TSHARE-MAI LP',
-    tokenDescription: 'TombSwap (Tomb)',
+    tokenDescription: 'TombSwap',
     tokenAddress: '0x67B2fAF48C1710fF1d2a9AC429b726B8F63eE83C',
     tokenDecimals: 18,
     tokenDescriptionUrl: '#',
@@ -123,7 +123,7 @@ export const fantomPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
-    platform: 'TombFinance',
+    platform: 'Tomb',
     assets: ['TSHARE', 'MAI'],
     risks: [
       'COMPLEXITY_LOW',
@@ -231,7 +231,7 @@ export const fantomPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
-    platform: 'TombFinance',
+    platform: 'Tomb',
     assets: ['TOMB', 'FTM'],
     risks: [
       'COMPLEXITY_LOW',
@@ -592,7 +592,7 @@ export const fantomPools = [
     id: 'tomb-tomb-mai',
     name: 'TOMB-MAI LP',
     token: 'TOMB-MAI LP',
-    tokenDescription: 'TombSwap (Tomb)',
+    tokenDescription: 'TombSwap',
     tokenAddress: '0x45f4682B560d4e3B8FF1F1b3A38FDBe775C7177b',
     tokenDecimals: 18,
     tokenDescriptionUrl: '#',
@@ -606,7 +606,7 @@ export const fantomPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
-    platform: 'TombFinance',
+    platform: 'Tomb',
     assets: ['TOMB', 'MAI'],
     risks: [
       'COMPLEXITY_LOW',
@@ -6493,7 +6493,7 @@ export const fantomPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
-    platform: 'TombFinance',
+    platform: 'Tomb',
     assets: ['TSHARE', 'FTM'],
     risks: [
       'COMPLEXITY_LOW',
@@ -6529,7 +6529,7 @@ export const fantomPools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
-    platform: 'TombFinance',
+    platform: 'Tomb',
     assets: ['TOMB', 'FTM'],
     risks: [
       'COMPLEXITY_LOW',


### PR DESCRIPTION
New alignment for Tomb related vaults:
tokenDescripton: TombSwap <optionally the farm provider in brackets, if not TombSwap itself>
platform: Tomb (The protocol changed their name and domain to Tomb.com)