### PR TITLE
Use AuroraScan API for `yarn creationdate` on Aurora

### DIFF
--- a/scripts/getPoolCreationTimestamp.js
+++ b/scripts/getPoolCreationTimestamp.js
@@ -13,13 +13,13 @@ const explorerApiUrls = {
   celo: 'https://explorer.celo.org/',
   moonriver: 'https://api-moonriver.moonscan.io/api',
   arbitrum: 'https://api.arbiscan.io/api',
-  aurora: 'https://explorer.mainnet.aurora.dev/',
+  aurora: 'https://api.aurorascan.dev/api',
   metis: 'https://andromeda-explorer.metis.io/',
   one: 'https://explorer.harmony.one/',
   fuse: 'https://explorer.fuse.io/',
 };
 
-const blockScoutChainsTimeout = new Set(['fuse', 'aurora', 'metis', 'celo']);
+const blockScoutChainsTimeout = new Set(['fuse', 'metis', 'celo']);
 const harmonyRpcChains = new Set(['one']);
 
 const getCreationTimestamp = async (vaultAddress, explorerUrl) => {


### PR DESCRIPTION
I had issues running `yarn creationdate` for Aurora-based vaults. Looks like the BlockScout scraping wasn't working correctly:

```
yarn creationdate tri-linear-near aurora  
yarn run v1.22.17
$ node ./scripts/getPoolCreationTimestamp.js tri-linear-near aurora
BlockScout explorer detected for this chain, proceeding to scrape
TypeError: Cannot read property 'split' of undefined
    at getCreationTimestampBlockScoutScraping (file:////Code/beefy.finance/app/scripts/getPoolCreationTimestamp.js:43:78)
...
```

However, Aurora has recently (~2 months ago) received their own Etherscan version, AuroraScan, which comes with the usual API. 

This PR updates the `getPoolCreationTimestamp.js` script to use the AuroraScan API instead of scraping BlockScout on Aurora.