### PR TITLE
Update SpookySwap URLs to new domain

### DIFF
--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -31,7 +31,7 @@ export const fantomPools = [
     stratType: 'Maxi',
     withdrawalFee: '0.05%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
+      'https://spooky.fi/#/swap?outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
     createdAt: 1622574935,
   },
   {
@@ -125,10 +125,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x74E23dF9110Aa9eA0b6ff2fAEE01e740CA1c642e',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x74E23dF9110Aa9eA0b6ff2fAEE01e740CA1c642e',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x74E23dF9110Aa9eA0b6ff2fAEE01e740CA1c642e',
+      'https://spooky.fi/#/swap?outputCurrency=0x74E23dF9110Aa9eA0b6ff2fAEE01e740CA1c642e',
     createdAt: 1651814013,
   },
   {
@@ -303,9 +302,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0xDE12c7959E1a72bbe8a5f7A1dc8f8EeF9Ab011B3/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+      'https://spooky.fi/#/add/0xDE12c7959E1a72bbe8a5f7A1dc8f8EeF9Ab011B3/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xDE12c7959E1a72bbe8a5f7A1dc8f8EeF9Ab011B3',
+      'https://spooky.fi/#/swap?outputCurrency=0xDE12c7959E1a72bbe8a5f7A1dc8f8EeF9Ab011B3',
     createdAt: 1649955002,
   },
   {
@@ -339,9 +338,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83/0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1',
+      'https://spooky.fi/#/add/0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83/0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1',
+      'https://spooky.fi/#/swap?outputCurrency=0xd7028092c830b5C8FcE061Af2E593413EbbC1fc1',
     createdAt: 1650967301,
   },
   {
@@ -374,10 +373,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44/FTM',
+    addLiquidityUrl: 'https://spooky.fi/#/add/0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44/FTM',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44',
+      'https://spooky.fi/#/swap?outputCurrency=0xDE5ed76E7c05eC5e4572CfC88d1ACEA165109E44',
     createdAt: 1649955001,
   },
   {
@@ -479,10 +477,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x593AE1d34c8BD7587C11D539E4F42BFf242c82Af',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x593AE1d34c8BD7587C11D539E4F42BFf242c82Af',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x593AE1d34c8BD7587C11D539E4F42BFf242c82Af',
+      'https://spooky.fi/#/swap?outputCurrency=0x593AE1d34c8BD7587C11D539E4F42BFf242c82Af',
     createdAt: 1649436436,
   },
   {
@@ -515,10 +512,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x846e4D51d7E2043C1a87E0Ab7490B93FB940357b',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x846e4D51d7E2043C1a87E0Ab7490B93FB940357b',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x846e4D51d7E2043C1a87E0Ab7490B93FB940357b',
+      'https://spooky.fi/#/swap?outputCurrency=0x846e4D51d7E2043C1a87E0Ab7490B93FB940357b',
     createdAt: 1649492747,
   },
   {
@@ -756,7 +752,7 @@ export const fantomPools = [
     withdrawalFee: '0%',
     addLiquidityUrl: 'https://stargate.finance/pool/USDC-FTM',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+      'https://spooky.fi/#/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     createdAt: 1648657158,
   },
   {
@@ -789,10 +785,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/0x7381eD41F6dE418DdE5e84B55590422a57917886/FTM',
+    addLiquidityUrl: 'https://spooky.fi/#/add/0x7381eD41F6dE418DdE5e84B55590422a57917886/FTM',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x7381eD41F6dE418DdE5e84B55590422a57917886',
+      'https://spooky.fi/#/swap?outputCurrency=0x7381eD41F6dE418DdE5e84B55590422a57917886',
     createdAt: 1648777474,
   },
   {
@@ -863,9 +858,9 @@ export const fantomPools = [
     depositFee: '0.2%',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae/0x49C290Ff692149A4E16611c694fdED42C954ab7a',
+      'https://spooky.fi/#/add/0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae/0x49C290Ff692149A4E16611c694fdED42C954ab7a',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae&outputCurrency=0x49C290Ff692149A4E16611c694fdED42C954ab7a',
+      'https://spooky.fi/#/swap?inputCurrency=0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae&outputCurrency=0x49C290Ff692149A4E16611c694fdED42C954ab7a',
     createdAt: 1648136284,
   },
   {
@@ -981,10 +976,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x2d72A97a31Dc920dB03330780d30074626e39C8A',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x2d72A97a31Dc920dB03330780d30074626e39C8A',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x2d72A97a31Dc920dB03330780d30074626e39C8A',
+      'https://spooky.fi/#/swap?outputCurrency=0x2d72A97a31Dc920dB03330780d30074626e39C8A',
     createdAt: 1648237084,
   },
   {
@@ -1018,9 +1012,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
+      'https://spooky.fi/#/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
+      'https://spooky.fi/#/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
     createdAt: 1648237004,
   },
   {
@@ -1431,9 +1425,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7/0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae',
+      'https://spooky.fi/#/add/0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7/0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae',
+      'https://spooky.fi/#/swap?outputCurrency=0x8D7d3409881b51466B483B11Ea1B8A03cdEd89ae',
     createdAt: 1646398565,
   },
   {
@@ -1466,10 +1460,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x49C290Ff692149A4E16611c694fdED42C954ab7a',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x49C290Ff692149A4E16611c694fdED42C954ab7a',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x49C290Ff692149A4E16611c694fdED42C954ab7a',
+      'https://spooky.fi/#/swap?outputCurrency=0x49C290Ff692149A4E16611c694fdED42C954ab7a',
     createdAt: 1646398565,
   },
   {
@@ -2206,10 +2199,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x65Def5029A0e7591e46B38742bFEdd1Fb7b24436',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x65Def5029A0e7591e46B38742bFEdd1Fb7b24436',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x65Def5029A0e7591e46B38742bFEdd1Fb7b24436',
+      'https://spooky.fi/#/swap?outputCurrency=0x65Def5029A0e7591e46B38742bFEdd1Fb7b24436',
     createdAt: 1645886552,
   },
   {
@@ -2271,10 +2263,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x9fb9a33956351cf4fa040f65a13b835a3c8764e3',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x9fb9a33956351cf4fa040f65a13b835a3c8764e3',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x9fb9a33956351cf4fa040f65a13b835a3c8764e3',
+      'https://spooky.fi/#/swap?outputCurrency=0x9fb9a33956351cf4fa040f65a13b835a3c8764e3',
     createdAt: 1645049415,
   },
   {
@@ -2472,10 +2463,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x112dF7E3b4B7Ab424F07319D4E92F41e6608c48B',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x112dF7E3b4B7Ab424F07319D4E92F41e6608c48B',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x112dF7E3b4B7Ab424F07319D4E92F41e6608c48B',
+      'https://spooky.fi/#/swap?outputCurrency=0x112dF7E3b4B7Ab424F07319D4E92F41e6608c48B',
     createdAt: 1644485111,
   },
   {
@@ -2508,10 +2498,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x8a41f13a4FaE75ca88B1ee726ee9D52B148b0498',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x8a41f13a4FaE75ca88B1ee726ee9D52B148b0498',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8a41f13a4FaE75ca88B1ee726ee9D52B148b0498',
+      'https://spooky.fi/#/swap?outputCurrency=0x8a41f13a4FaE75ca88B1ee726ee9D52B148b0498',
     createdAt: 1644485584,
   },
   {
@@ -2546,9 +2535,8 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x152888854378201e173490956085c711f1DeD565',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x152888854378201e173490956085c711f1DeD565',
+      'https://spooky.fi/#/swap?outputCurrency=0x152888854378201e173490956085c711f1DeD565',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x152888854378201e173490956085c711f1DeD565',
     createdAt: 1644813183,
   },
   {
@@ -2912,9 +2900,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xC758295Cd1A564cdb020a78a681a838CF8e0627D',
+      'https://spooky.fi/#/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xC758295Cd1A564cdb020a78a681a838CF8e0627D',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0xC758295Cd1A564cdb020a78a681a838CF8e0627D',
+      'https://spooky.fi/#/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0xC758295Cd1A564cdb020a78a681a838CF8e0627D',
     createdAt: 1644274576,
   },
   {
@@ -2947,10 +2935,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xbbc4a8d076f4b1888fec42581b6fc58d242cf2d5',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xbbc4a8d076f4b1888fec42581b6fc58d242cf2d5',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xbbc4A8d076F4B1888fec42581B6fc58d242CF2D5',
+      'https://spooky.fi/#/swap?outputCurrency=0xbbc4A8d076F4B1888fec42581B6fc58d242CF2D5',
     createdAt: 1644614666,
   },
   {
@@ -3093,9 +3080,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE/0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
+      'https://spooky.fi/#/add/0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE/0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE&outputCurrency=0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
+      'https://spooky.fi/#/swap?inputCurrency=0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE&outputCurrency=0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
     createdAt: 1644007618,
   },
   {
@@ -3196,7 +3183,7 @@ export const fantomPools = [
     withdrawalFee: '0%',
     addLiquidityUrl: 'https://scream.sh/stake',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
+      'https://spooky.fi/#/swap?outputCurrency=0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
     createdAt: 1643612827,
   },
   {
@@ -3231,9 +3218,9 @@ export const fantomPools = [
     ],
     stratType: 'SingleStake',
     withdrawalFee: '0%',
-    addLiquidityUrl: 'https://spookyswap.finance/pools',
+    addLiquidityUrl: 'https://spooky.fi/#/pools',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
+      'https://spooky.fi/#/swap?outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
     createdAt: 1643099828,
   },
   {
@@ -3266,7 +3253,7 @@ export const fantomPools = [
     ],
     stratType: 'Lending',
     withdrawalFee: '0%',
-    buyTokenUrl: 'https://spookyswap.finance/swap?outputCurrency=FTM',
+    buyTokenUrl: 'https://spooky.fi/#/swap?outputCurrency=FTM',
     createdAt: 1628734094,
   },
   {
@@ -3302,7 +3289,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xc165d941481e68696f43EE6E99BFB2B23E0E3114',
+      'https://spooky.fi/#/swap?outputCurrency=0xc165d941481e68696f43EE6E99BFB2B23E0E3114',
     createdAt: 1643104856,
   },
   {
@@ -3588,7 +3575,7 @@ export const fantomPools = [
     ],
     stratType: 'SingleStake',
     withdrawalFee: '0%',
-    buyTokenUrl: 'https://spookyswap.finance/swap?outputCurrency=FTM',
+    buyTokenUrl: 'https://spooky.fi/#/swap?outputCurrency=FTM',
     createdAt: 1642887314,
   },
   {
@@ -3624,7 +3611,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+      'https://spooky.fi/#/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     createdAt: 1642877204,
   },
   {
@@ -3660,7 +3647,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
+      'https://spooky.fi/#/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
     createdAt: 1642877428,
   },
   {
@@ -3696,7 +3683,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
+      'https://spooky.fi/#/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
     createdAt: 1642880855,
   },
   {
@@ -3732,7 +3719,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
+      'https://spooky.fi/#/swap?outputCurrency=0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
     createdAt: 1642865861,
   },
   {
@@ -3768,7 +3755,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
+      'https://spooky.fi/#/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
     createdAt: 1642875469,
   },
   {
@@ -3804,7 +3791,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
+      'https://spooky.fi/#/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
     createdAt: 1642860948,
   },
   {
@@ -3839,9 +3826,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0xc165d941481e68696f43EE6E99BFB2B23E0E3114/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+      'https://spooky.fi/#/add/0xc165d941481e68696f43EE6E99BFB2B23E0E3114/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xc165d941481e68696f43EE6E99BFB2B23E0E3114',
+      'https://spooky.fi/#/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xc165d941481e68696f43EE6E99BFB2B23E0E3114',
     createdAt: 1642811156,
   },
   {
@@ -3904,9 +3891,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0.01%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x74b23882a30290451A17c44f4F05243b6b58C76d/0x321162Cd933E2Be498Cd2267a90534A804051b11',
+      'https://spooky.fi/#/add/0x74b23882a30290451A17c44f4F05243b6b58C76d/0x321162Cd933E2Be498Cd2267a90534A804051b11',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d&outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
+      'https://spooky.fi/#/swap?inputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d&outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
     createdAt: 1642672280,
   },
   {
@@ -3939,10 +3926,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xF24Bcf4d1e507740041C9cFd2DddB29585aDCe1e',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xF24Bcf4d1e507740041C9cFd2DddB29585aDCe1e',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xF24Bcf4d1e507740041C9cFd2DddB29585aDCe1e',
+      'https://spooky.fi/#/swap?outputCurrency=0xF24Bcf4d1e507740041C9cFd2DddB29585aDCe1e',
     createdAt: 1642634017,
   },
   {
@@ -4085,10 +4071,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE',
+      'https://spooky.fi/#/swap?outputCurrency=0x7a6e4E3CC2ac9924605DCa4bA31d1831c84b44aE',
     createdAt: 1642150805,
   },
   {
@@ -4122,10 +4107,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
+      'https://spooky.fi/#/swap?outputCurrency=0xc54A1684fD1bef1f077a336E6be4Bd9a3096a6Ca',
     createdAt: 1642152342,
   },
   {
@@ -4158,10 +4142,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x85dec8c4B2680793661bCA91a8F129607571863d',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x85dec8c4B2680793661bCA91a8F129607571863d',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x85dec8c4B2680793661bCA91a8F129607571863d',
+      'https://spooky.fi/#/swap?outputCurrency=0x85dec8c4B2680793661bCA91a8F129607571863d',
     createdAt: 1642291662,
   },
   {
@@ -4195,10 +4178,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x627524d78B4fC840C887ffeC90563c7A42b671fD',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x627524d78B4fC840C887ffeC90563c7A42b671fD',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x627524d78B4fC840C887ffeC90563c7A42b671fD',
+      'https://spooky.fi/#/swap?outputCurrency=0x627524d78B4fC840C887ffeC90563c7A42b671fD',
     createdAt: 1642139577,
   },
   {
@@ -4232,10 +4214,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
+      'https://spooky.fi/#/swap?outputCurrency=0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
     createdAt: 1642097531,
   },
   {
@@ -4409,10 +4390,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x10010078a54396F62c96dF8532dc2B4847d47ED3',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x10010078a54396F62c96dF8532dc2B4847d47ED3',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x10010078a54396F62c96dF8532dc2B4847d47ED3',
+      'https://spooky.fi/#/swap?outputCurrency=0x10010078a54396F62c96dF8532dc2B4847d47ED3',
     createdAt: 1641572631,
   },
   {
@@ -4482,9 +4462,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0.1%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x04068da6c83afcfa0e13ba15a6696662335d5b75/0x248cb87dda803028dfead98101c9465a2fbda0d4',
+      'https://spooky.fi/#/add/0x04068da6c83afcfa0e13ba15a6696662335d5b75/0x248cb87dda803028dfead98101c9465a2fbda0d4',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x248cb87dda803028dfead98101c9465a2fbda0d4',
+      'https://spooky.fi/#/swap?outputCurrency=0x248cb87dda803028dfead98101c9465a2fbda0d4',
     createdAt: 1641550679,
   },
   {
@@ -4545,10 +4525,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x40DF1Ae6074C35047BFF66675488Aa2f9f6384F3',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x40DF1Ae6074C35047BFF66675488Aa2f9f6384F3',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x40DF1Ae6074C35047BFF66675488Aa2f9f6384F3',
+      'https://spooky.fi/#/swap?outputCurrency=0x40DF1Ae6074C35047BFF66675488Aa2f9f6384F3',
     createdAt: 1640973310,
   },
   {
@@ -4649,7 +4628,7 @@ export const fantomPools = [
     showWarning: false,
     warning: 'liquidity',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x468003B688943977e6130F4F68F23aad939a1040',
+      'https://spooky.fi/#/swap?outputCurrency=0x468003B688943977e6130F4F68F23aad939a1040',
     createdAt: 1640646636,
   },
   {
@@ -4757,7 +4736,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
+      'https://spooky.fi/#/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
     createdAt: 1640092257,
   },
   {
@@ -4820,7 +4799,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x1E4F97b9f9F913c46F1632781732927B9019C68b',
+      'https://spooky.fi/#/swap?outputCurrency=0x1E4F97b9f9F913c46F1632781732927B9019C68b',
     createdAt: 1639737670,
   },
   {
@@ -4853,10 +4832,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x511D35c52a3C244E7b8bd92c0C297755FbD89212',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x511D35c52a3C244E7b8bd92c0C297755FbD89212',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x511D35c52a3C244E7b8bd92c0C297755FbD89212',
+      'https://spooky.fi/#/swap?outputCurrency=0x511D35c52a3C244E7b8bd92c0C297755FbD89212',
     createdAt: 1639923705,
   },
   {
@@ -4889,10 +4867,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x6626c47c00F1D87902fc13EECfaC3ed06D5E8D8a',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x6626c47c00F1D87902fc13EECfaC3ed06D5E8D8a',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x6626c47c00F1D87902fc13EECfaC3ed06D5E8D8a',
+      'https://spooky.fi/#/swap?outputCurrency=0x6626c47c00F1D87902fc13EECfaC3ed06D5E8D8a',
     createdAt: 1639923811,
   },
   {
@@ -4925,10 +4902,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x9d8F97A3C2f9f397B6D46Cbe2d39CC1D8Cf19010',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x9d8F97A3C2f9f397B6D46Cbe2d39CC1D8Cf19010',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x9d8F97A3C2f9f397B6D46Cbe2d39CC1D8Cf19010',
+      'https://spooky.fi/#/swap?outputCurrency=0x9d8F97A3C2f9f397B6D46Cbe2d39CC1D8Cf19010',
     createdAt: 1639423285,
   },
   {
@@ -4961,10 +4937,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x94CcF60f700146BeA8eF7832820800E2dFa92EdA',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x94CcF60f700146BeA8eF7832820800E2dFa92EdA',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x94CcF60f700146BeA8eF7832820800E2dFa92EdA',
+      'https://spooky.fi/#/swap?outputCurrency=0x94CcF60f700146BeA8eF7832820800E2dFa92EdA',
     createdAt: 1639423158,
   },
   {
@@ -4998,10 +4973,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x89346B51A54263cF2e92dA79B1863759eFa68692',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x89346B51A54263cF2e92dA79B1863759eFa68692',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x89346B51A54263cF2e92dA79B1863759eFa68692',
+      'https://spooky.fi/#/swap?outputCurrency=0x89346B51A54263cF2e92dA79B1863759eFa68692',
     createdAt: 1639423010,
   },
   {
@@ -5034,10 +5008,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x3dc57B391262e3aAe37a08D91241f9bA9d58b570',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x3dc57B391262e3aAe37a08D91241f9bA9d58b570',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x3dc57B391262e3aAe37a08D91241f9bA9d58b570',
+      'https://spooky.fi/#/swap?outputCurrency=0x3dc57B391262e3aAe37a08D91241f9bA9d58b570',
     createdAt: 1639422895,
   },
   {
@@ -5131,7 +5104,7 @@ export const fantomPools = [
     showWarning: false,
     warning: 'liquidity',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x9879aBDea01a879644185341F7aF7d8343556B7a',
+      'https://spooky.fi/#/swap?outputCurrency=0x9879aBDea01a879644185341F7aF7d8343556B7a',
     createdAt: 1637875008,
   },
   {
@@ -5193,9 +5166,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0x9879aBDea01a879644185341F7aF7d8343556B7a',
+      'https://spooky.fi/#/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0x9879aBDea01a879644185341F7aF7d8343556B7a',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0x9879aBDea01a879644185341F7aF7d8343556B7a',
+      'https://spooky.fi/#/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0x9879aBDea01a879644185341F7aF7d8343556B7a',
     createdAt: 1637658328,
   },
   {
@@ -5228,10 +5201,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x9F47F313ACFd4bdC52F4373b493EaE7d5aC5b765',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x9F47F313ACFd4bdC52F4373b493EaE7d5aC5b765',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x9F47F313ACFd4bdC52F4373b493EaE7d5aC5b765',
+      'https://spooky.fi/#/swap?outputCurrency=0x9F47F313ACFd4bdC52F4373b493EaE7d5aC5b765',
     createdAt: 1637587170,
   },
   {
@@ -5330,9 +5302,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xfB98B335551a418cD0737375a2ea0ded62Ea213b',
+      'https://spooky.fi/#/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xfB98B335551a418cD0737375a2ea0ded62Ea213b',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0xfB98B335551a418cD0737375a2ea0ded62Ea213b',
+      'https://spooky.fi/#/add/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75/0xfB98B335551a418cD0737375a2ea0ded62Ea213b',
     createdAt: 1636758731,
   },
   {
@@ -5365,7 +5337,7 @@ export const fantomPools = [
     ],
     stratType: 'Lending',
     withdrawalFee: '0.01%',
-    buyTokenUrl: 'https://spookyswap.finance/swap?outputCurrency=FTM',
+    buyTokenUrl: 'https://spooky.fi/#/swap?outputCurrency=FTM',
     createdAt: 1636115081,
   },
   {
@@ -5400,7 +5372,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
+      'https://spooky.fi/#/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
     createdAt: 1636111832,
   },
   {
@@ -5435,7 +5407,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
+      'https://spooky.fi/#/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
     createdAt: 1636106243,
   },
   {
@@ -5471,7 +5443,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x049d68029688eAbF473097a2fC38ef61633A3C7A',
+      'https://spooky.fi/#/swap?outputCurrency=0x049d68029688eAbF473097a2fC38ef61633A3C7A',
     createdAt: 1636108542,
   },
   {
@@ -5506,7 +5478,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+      'https://spooky.fi/#/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     createdAt: 1636126692,
   },
   {
@@ -5541,7 +5513,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
+      'https://spooky.fi/#/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
     createdAt: 1636100990,
     retiredReason: 'tvl',
   },
@@ -5661,9 +5633,8 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c',
+      'https://spooky.fi/#/swap?outputCurrency=0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c',
     createdAt: 1635415386,
   },
   {
@@ -5698,9 +5669,9 @@ export const fantomPools = [
     withdrawalFee: '0%',
     retireReason: 'rewards',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
+      'https://spooky.fi/#/swap?outputCurrency=0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c/0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
+      'https://spooky.fi/#/add/0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c/0xb84527D59b6Ecb96F433029ECc890D4492C5dCe1',
     createdAt: 1635418613,
   },
   {
@@ -5735,7 +5706,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c',
+      'https://spooky.fi/#/swap?outputCurrency=0x3129662808bEC728a27Ab6a6b9AFd3cBacA8A43c',
     createdAt: 1635454839,
   },
   {
@@ -5792,7 +5763,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8F9bCCB6Dd999148Da1808aC290F2274b13D7994',
+      'https://spooky.fi/#/swap?outputCurrency=0x8F9bCCB6Dd999148Da1808aC290F2274b13D7994',
     createdAt: 1635336610,
   },
   {
@@ -5819,10 +5790,9 @@ export const fantomPools = [
     risks: ['COMPLEXITY_LOW', 'NEW_STRAT', 'IL_HIGH', 'MCAP_MICRO', 'AUDIT', 'CONTRACTS_VERIFIED'],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x8F9bCCB6Dd999148Da1808aC290F2274b13D7994',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x8F9bCCB6Dd999148Da1808aC290F2274b13D7994',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8F9bCCB6Dd999148Da1808aC290F2274b13D7994',
+      'https://spooky.fi/#/swap?outputCurrency=0x8F9bCCB6Dd999148Da1808aC290F2274b13D7994',
     createdAt: 1635338766,
   },
   {
@@ -6327,7 +6297,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
+      'https://spooky.fi/#/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
     createdAt: 1634453638,
   },
   {
@@ -6430,10 +6400,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xd8321AA83Fb0a4ECd6348D4577431310A6E0814d',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xd8321AA83Fb0a4ECd6348D4577431310A6E0814d',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xd8321AA83Fb0a4ECd6348D4577431310A6E0814d',
+      'https://spooky.fi/#/swap?outputCurrency=0xd8321AA83Fb0a4ECd6348D4577431310A6E0814d',
     createdAt: 1633607188,
   },
   {
@@ -6466,10 +6435,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x468003B688943977e6130F4F68F23aad939a1040',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x468003B688943977e6130F4F68F23aad939a1040',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x468003B688943977e6130F4F68F23aad939a1040',
+      'https://spooky.fi/#/swap?outputCurrency=0x468003B688943977e6130F4F68F23aad939a1040',
     createdAt: 1634118092,
   },
   {
@@ -6603,10 +6571,9 @@ export const fantomPools = [
     risks: ['COMPLEXITY_LOW', 'NEW_STRAT', 'IL_HIGH', 'MCAP_MICRO', 'AUDIT', 'CONTRACTS_VERIFIED'],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x53D831e1db0947c74e8a52618f662209ec5dE0cE',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x53D831e1db0947c74e8a52618f662209ec5dE0cE',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x53D831e1db0947c74e8a52618f662209ec5dE0cE',
+      'https://spooky.fi/#/swap?outputCurrency=0x53D831e1db0947c74e8a52618f662209ec5dE0cE',
     createdAt: 1634116608,
     retiredReason: 'tvl',
   },
@@ -7100,10 +7067,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x4cdF39285D7Ca8eB3f090fDA0C069ba5F4145B37',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x4cdF39285D7Ca8eB3f090fDA0C069ba5F4145B37',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x4cdF39285D7Ca8eB3f090fDA0C069ba5F4145B37',
+      'https://spooky.fi/#/swap?outputCurrency=0x4cdF39285D7Ca8eB3f090fDA0C069ba5F4145B37',
     createdAt: 1623662472,
   },
   {
@@ -7136,10 +7102,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
+      'https://spooky.fi/#/swap?outputCurrency=0x6c021Ae822BEa943b2E66552bDe1D2696a53fbB7',
     createdAt: 1623659891,
   },
   {
@@ -7284,10 +7249,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     retireReason: 'rewards',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x3A3841f5fa9f2c283EA567d5Aeea3Af022dD2262',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x3A3841f5fa9f2c283EA567d5Aeea3Af022dD2262',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x3A3841f5fa9f2c283EA567d5Aeea3Af022dD2262',
+      'https://spooky.fi/#/swap?outputCurrency=0x3A3841f5fa9f2c283EA567d5Aeea3Af022dD2262',
     createdAt: 1631898051,
   },
   {
@@ -7320,10 +7284,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xc60D7067dfBc6f2caf30523a064f416A5Af52963',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xc60D7067dfBc6f2caf30523a064f416A5Af52963',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xc60D7067dfBc6f2caf30523a064f416A5Af52963',
+      'https://spooky.fi/#/swap?outputCurrency=0xc60D7067dfBc6f2caf30523a064f416A5Af52963',
     createdAt: 1631897760,
   },
   {
@@ -7358,7 +7321,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x1E4F97b9f9F913c46F1632781732927B9019C68b',
+      'https://spooky.fi/#/swap?outputCurrency=0x1E4F97b9f9F913c46F1632781732927B9019C68b',
     createdAt: 1631727659,
   },
   {
@@ -7393,7 +7356,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xb3654dc3D10Ea7645f8319668E8F54d2574FBdC8',
+      'https://spooky.fi/#/swap?outputCurrency=0xb3654dc3D10Ea7645f8319668E8F54d2574FBdC8',
     createdAt: 1631726729,
   },
   {
@@ -7428,7 +7391,7 @@ export const fantomPools = [
     stratType: 'SingleStake',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
+      'https://spooky.fi/#/swap?outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
     createdAt: 1620998574,
   },
   {
@@ -7465,7 +7428,7 @@ export const fantomPools = [
     addLiquidityUrl: 'https://stakesteak.app/',
     retireReason: 'tvl',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xAd84341756Bf337f5a0164515b1f6F993D194E1f',
+      'https://spooky.fi/#/swap?inputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75&outputCurrency=0xAd84341756Bf337f5a0164515b1f6F993D194E1f',
     createdAt: 1631357355,
   },
   {
@@ -7499,10 +7462,9 @@ export const fantomPools = [
     stratType: 'StratLP',
     withdrawalFee: '0%',
     retireReason: 'rewards',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x05848B832E872d9eDd84AC5718D58f21fD9c9649',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x05848B832E872d9eDd84AC5718D58f21fD9c9649',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x05848B832E872d9eDd84AC5718D58f21fD9c9649',
+      'https://spooky.fi/#/swap?outputCurrency=0x05848B832E872d9eDd84AC5718D58f21fD9c9649',
     createdAt: 1631055499,
   },
   {
@@ -7536,10 +7498,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     withdrawalFee: '0%',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xFbc3c04845162F067A0B6F8934383E63899c3524',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xFbc3c04845162F067A0B6F8934383E63899c3524',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xFbc3c04845162F067A0B6F8934383E63899c3524',
+      'https://spooky.fi/#/swap?outputCurrency=0xFbc3c04845162F067A0B6F8934383E63899c3524',
     createdAt: 1631054248,
   },
   {
@@ -7571,10 +7532,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
+      'https://spooky.fi/#/swap?outputCurrency=0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
     createdAt: 1630352068,
     retiredReason: 'tvl',
   },
@@ -7608,10 +7568,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     retireReason: 'rewards',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x09e145A1D53c0045F41aEEf25D8ff982ae74dD56',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x09e145A1D53c0045F41aEEf25D8ff982ae74dD56',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x09e145A1D53c0045F41aEEf25D8ff982ae74dD56',
+      'https://spooky.fi/#/swap?outputCurrency=0x09e145A1D53c0045F41aEEf25D8ff982ae74dD56',
     createdAt: 1630243343,
   },
   {
@@ -7645,10 +7604,9 @@ export const fantomPools = [
     depositFee: '0.5%',
     withdrawalFee: '0%',
     platform: 'Other',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
+      'https://spooky.fi/#/swap?outputCurrency=0xe0654C8e6fd4D733349ac7E09f6f23DA256bF475',
     createdAt: 1628881379,
   },
   {
@@ -7683,7 +7641,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+      'https://spooky.fi/#/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     createdAt: 1628627757,
   },
   {
@@ -7718,7 +7676,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0.01%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
+      'https://spooky.fi/#/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
     createdAt: 1628739572,
   },
   {
@@ -7753,7 +7711,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
+      'https://spooky.fi/#/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
     createdAt: 1628739318,
   },
   {
@@ -7788,7 +7746,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
+      'https://spooky.fi/#/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
     createdAt: 1628739417,
   },
   {
@@ -7823,7 +7781,7 @@ export const fantomPools = [
     stratType: 'Lending',
     withdrawalFee: '0%',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x049d68029688eAbF473097a2fC38ef61633A3C7A',
+      'https://spooky.fi/#/swap?outputCurrency=0x049d68029688eAbF473097a2fC38ef61633A3C7A',
     createdAt: 1628739191,
   },
   {
@@ -7856,9 +7814,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     addLiquidityUrl:
-      'https://spookyswap.finance/add/0x29b0Da86e484E1C0029B56e817912d778aC0EC69/0x74b23882a30290451A17c44f4F05243b6b58C76d',
+      'https://spooky.fi/#/add/0x29b0Da86e484E1C0029B56e817912d778aC0EC69/0x74b23882a30290451A17c44f4F05243b6b58C76d',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?inputCurrency=0x29b0Da86e484E1C0029B56e817912d778aC0EC69&outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
+      'https://spooky.fi/#/swap?inputCurrency=0x29b0Da86e484E1C0029B56e817912d778aC0EC69&outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
     createdAt: 1628168514,
   },
   {
@@ -7993,10 +7951,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x82f0B8B456c1A451378467398982d4834b6829c1',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x82f0B8B456c1A451378467398982d4834b6829c1',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
+      'https://spooky.fi/#/swap?outputCurrency=0x82f0B8B456c1A451378467398982d4834b6829c1',
     createdAt: 1625679284,
   },
   {
@@ -8028,10 +7985,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
+      'https://spooky.fi/#/swap?outputCurrency=0x841FAD6EAe12c286d1Fd18d1d525DFfA75C7EFFE',
     createdAt: 1620386574,
   },
   {
@@ -8063,10 +8019,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xd6070ae98b8069de6B494332d1A1a81B6179D960',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xd6070ae98b8069de6B494332d1A1a81B6179D960',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
+      'https://spooky.fi/#/swap?outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
     createdAt: 1622569266,
   },
   {
@@ -8098,10 +8053,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xf16e81dce15B08F326220742020379B855B87DF9',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xf16e81dce15B08F326220742020379B855B87DF9',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xf16e81dce15B08F326220742020379B855B87DF9',
+      'https://spooky.fi/#/swap?outputCurrency=0xf16e81dce15B08F326220742020379B855B87DF9',
     createdAt: 1622445591,
   },
   {
@@ -8133,10 +8087,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xae75A438b2E0cB8Bb01Ec1E1e376De11D44477CC',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xae75A438b2E0cB8Bb01Ec1E1e376De11D44477CC',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xae75A438b2E0cB8Bb01Ec1E1e376De11D44477CC',
+      'https://spooky.fi/#/swap?outputCurrency=0xae75A438b2E0cB8Bb01Ec1E1e376De11D44477CC',
     createdAt: 1622446524,
   },
   {
@@ -8168,10 +8121,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
+      'https://spooky.fi/#/swap?outputCurrency=0x04068DA6C83AFCFA0e13ba15A6696662335D5B75',
     createdAt: 1620386549,
   },
   {
@@ -8203,10 +8155,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xdDcb3fFD12750B45d32E084887fdf1aABAb34239',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xdDcb3fFD12750B45d32E084887fdf1aABAb34239',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xdDcb3fFD12750B45d32E084887fdf1aABAb34239',
+      'https://spooky.fi/#/swap?outputCurrency=0xdDcb3fFD12750B45d32E084887fdf1aABAb34239',
     createdAt: 1622123539,
   },
   {
@@ -8238,10 +8189,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
+      'https://spooky.fi/#/swap?outputCurrency=0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E',
     createdAt: 1622123567,
   },
   {
@@ -8345,10 +8295,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     retireReason: 'rewards',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xD0660cD418a64a1d44E9214ad8e459324D8157f1',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xD0660cD418a64a1d44E9214ad8e459324D8157f1',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xD0660cD418a64a1d44E9214ad8e459324D8157f1',
+      'https://spooky.fi/#/swap?outputCurrency=0xD0660cD418a64a1d44E9214ad8e459324D8157f1',
     createdAt: 1621266087,
   },
   {
@@ -8380,10 +8329,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xD67de0e0a0Fd7b15dC8348Bb9BE742F3c5850454',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xD67de0e0a0Fd7b15dC8348Bb9BE742F3c5850454',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xD67de0e0a0Fd7b15dC8348Bb9BE742F3c5850454',
+      'https://spooky.fi/#/swap?outputCurrency=0xD67de0e0a0Fd7b15dC8348Bb9BE742F3c5850454',
     createdAt: 1620919260,
   },
   {
@@ -8484,10 +8432,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xb3654dc3D10Ea7645f8319668E8F54d2574FBdC8',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xb3654dc3D10Ea7645f8319668E8F54d2574FBdC8',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xb3654dc3D10Ea7645f8319668E8F54d2574FBdC8',
+      'https://spooky.fi/#/swap?outputCurrency=0xb3654dc3D10Ea7645f8319668E8F54d2574FBdC8',
     createdAt: 1620500758,
   },
   {
@@ -8511,10 +8458,9 @@ export const fantomPools = [
     retireReason: 'rewards',
     platform: 'SpookySwap',
     assets: ['COVER', 'FTM'],
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0xB01E8419d842beebf1b70A7b5f7142abbaf7159D',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0xB01E8419d842beebf1b70A7b5f7142abbaf7159D',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0xB01E8419d842beebf1b70A7b5f7142abbaf7159D',
+      'https://spooky.fi/#/swap?outputCurrency=0xB01E8419d842beebf1b70A7b5f7142abbaf7159D',
     createdAt: 1620500733,
   },
   {
@@ -8547,10 +8493,9 @@ export const fantomPools = [
     ],
     stratType: 'StratLP',
     retireReason: 'rewards',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x56ee926bD8c72B2d5fa1aF4d9E4Cbb515a1E3Adc',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x56ee926bD8c72B2d5fa1aF4d9E4Cbb515a1E3Adc',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x56ee926bD8c72B2d5fa1aF4d9E4Cbb515a1E3Adc',
+      'https://spooky.fi/#/swap?outputCurrency=0x56ee926bD8c72B2d5fa1aF4d9E4Cbb515a1E3Adc',
     createdAt: 1620500694,
   },
   {
@@ -8582,10 +8527,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x049d68029688eAbF473097a2fC38ef61633A3C7A',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x049d68029688eAbF473097a2fC38ef61633A3C7A',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x049d68029688eAbF473097a2fC38ef61633A3C7A',
+      'https://spooky.fi/#/swap?outputCurrency=0x049d68029688eAbF473097a2fC38ef61633A3C7A',
     createdAt: 1620500483,
   },
   {
@@ -8617,10 +8561,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x321162Cd933E2Be498Cd2267a90534A804051b11',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x321162Cd933E2Be498Cd2267a90534A804051b11',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
+      'https://spooky.fi/#/swap?outputCurrency=0x321162Cd933E2Be498Cd2267a90534A804051b11',
     createdAt: 1620500455,
   },
   {
@@ -8652,10 +8595,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x74b23882a30290451A17c44f4F05243b6b58C76d',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x74b23882a30290451A17c44f4F05243b6b58C76d',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
+      'https://spooky.fi/#/swap?outputCurrency=0x74b23882a30290451A17c44f4F05243b6b58C76d',
     createdAt: 1620386666,
   },
   {
@@ -8688,10 +8630,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x6a07A792ab2965C72a5B8088d3a069A7aC3a993B',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x6a07A792ab2965C72a5B8088d3a069A7aC3a993B',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x6a07A792ab2965C72a5B8088d3a069A7aC3a993B',
+      'https://spooky.fi/#/swap?outputCurrency=0x6a07A792ab2965C72a5B8088d3a069A7aC3a993B',
     createdAt: 1620386633,
   },
   {
@@ -8723,10 +8664,9 @@ export const fantomPools = [
       'CONTRACTS_VERIFIED',
     ],
     stratType: 'StratLP',
-    addLiquidityUrl:
-      'https://spookyswap.finance/add/FTM/0x1E4F97b9f9F913c46F1632781732927B9019C68b',
+    addLiquidityUrl: 'https://spooky.fi/#/add/FTM/0x1E4F97b9f9F913c46F1632781732927B9019C68b',
     buyTokenUrl:
-      'https://spookyswap.finance/swap?outputCurrency=0x1E4F97b9f9F913c46F1632781732927B9019C68b',
+      'https://spooky.fi/#/swap?outputCurrency=0x1E4F97b9f9F913c46F1632781732927B9019C68b',
     createdAt: 1620386607,
   },
 ];

--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -645,7 +645,7 @@ export const fantomPools = [
     withdrawalFee: '0.01%',
     mintTokenUrl: 'https://beta.beefy.finance/#/fantom/vault/beefy-beFTM',
     buyTokenUrl:
-      'https://solidly.exchange/swap?outputCurrency=0x7381eD41F6dE418DdE5e84B55590422a57917886',
+      'https://spooky.fi/#/swap?outputCurrency=0x7381eD41F6dE418DdE5e84B55590422a57917886',
     createdAt: 1646162527,
   },
   {

--- a/src/features/helpers/getNetworkData.js
+++ b/src/features/helpers/getNetworkData.js
@@ -105,7 +105,7 @@ const networkBuyUrls = {
   56: 'https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B',
   128: 'https://ht.mdex.com/#/swap?inputCurrency=0xa71edc38d189767582c38a3145b5873052c3e47a&outputCurrency=0x765277eebeca2e31912c9946eae1021199b39c61',
   137: 'https://app.1inch.io/#/r/0xF4cb25a1FF50E319c267b3E51CBeC2699FB2A43B',
-  250: 'https://spookyswap.finance/swap?inputCurrency=0x04068da6c83afcfa0e13ba15a6696662335d5b75&outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
+  250: 'https://spooky.fi/#/swap?inputCurrency=0x04068da6c83afcfa0e13ba15a6696662335d5b75&outputCurrency=0xd6070ae98b8069de6B494332d1A1a81B6179D960',
   43114:
     'https://www.traderjoexyz.com/trade?outputCurrency=0xd6070ae98b8069de6b494332d1a1a81b6179d960',
   1666600000:


### PR DESCRIPTION
SpookySwap has updated their domain and is now showing a warning on the existing site:

![image](https://user-images.githubusercontent.com/98132670/167270911-d8ca5144-22db-40f7-abd9-d7010b4b7e39.png)

This updates all occurrences of `spookyswap.finance` to `spooky.fi`, also taking into consideration the new navigation using hash fragments. 

Also replaces the "Buy Token" link for Solidly.exchange on the `beefy-beFTM` vault with SpookySwap, since Solidly is now defunct.