### PR TITLE
Fix trader joe platform and EOL Vaults

### DIFF
--- a/src/features/configure/vault/aurora_pools.js
+++ b/src/features/configure/vault/aurora_pools.js
@@ -723,7 +723,7 @@ export const auroraPools = [
     createdAt: 1643737307,
   },
   {
-    id: 'trisolaris-usdt-near',
+    id: 'trisolaris-usdt-near-eol',
     name: 'NEAR-USDT LP',
     token: 'NEAR-USDT LP',
     tokenDescription: 'Trisolaris',
@@ -738,8 +738,9 @@ export const auroraPools = [
     oracle: 'lps',
     oracleId: 'trisolaris-usdt-near',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Trisolaris',
     assets: ['NEAR', 'USDT'],
     risks: [
@@ -758,7 +759,7 @@ export const auroraPools = [
     createdAt: 1643740691,
   },
   {
-    id: 'trisolaris-usdc-near',
+    id: 'trisolaris-usdc-near-eol',
     name: 'NEAR-USDC LP',
     token: 'NEAR-USDC LP',
     tokenDescription: 'Trisolaris',
@@ -773,8 +774,9 @@ export const auroraPools = [
     oracle: 'lps',
     oracleId: 'trisolaris-usdc-near',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Trisolaris',
     assets: ['NEAR', 'USDC'],
     risks: [

--- a/src/features/configure/vault/avalanche_pools.js
+++ b/src/features/configure/vault/avalanche_pools.js
@@ -53,7 +53,7 @@ export const avalanchePools = [
     oraclePrice: 0,
     depositsPaused: false,
     status: 'active',
-    platform: 'TraderJoe',
+    platform: 'Trader Joe',
     assets: ['TUS', 'AVAX'],
     risks: [
       'COMPLEXITY_LOW',

--- a/src/features/configure/vault/avalanche_pools.js
+++ b/src/features/configure/vault/avalanche_pools.js
@@ -36,7 +36,7 @@ export const avalanchePools = [
   },
 
   {
-    id: 'joe-tus-wavax',
+    id: 'joe-tus-wavax-eol',
     name: 'TUS-AVAX LP',
     token: 'TUS-AVAX JLP',
     tokenDescription: 'TraderJoe',
@@ -51,8 +51,9 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'joe-tus-wavax',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Trader Joe',
     assets: ['TUS', 'AVAX'],
     risks: [
@@ -430,7 +431,7 @@ export const avalanchePools = [
     createdAt: 1651836382,
   },
   {
-    id: 'joe-dby-wavax',
+    id: 'joe-dby-wavax-eol',
     name: 'DBY-AVAX LP',
     token: 'DBY-AVAX JLP',
     tokenDescription: 'Trader Joe',
@@ -445,8 +446,9 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'joe-dby-wavax',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Trader Joe',
     assets: ['DBY', 'AVAX'],
     risks: [
@@ -2441,7 +2443,7 @@ export const avalanchePools = [
     createdAt: 1643387033,
   },
   {
-    id: 'joe-wavax-hec',
+    id: 'joe-wavax-hec-eol',
     name: 'HEC-AVAX LP',
     token: 'HEC-AVAX JLP',
     tokenDescription: 'Trader Joe',
@@ -2456,8 +2458,9 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'joe-wavax-hec',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Trader Joe',
     assets: ['HEC', 'AVAX'],
     risks: [
@@ -4196,7 +4199,7 @@ export const avalanchePools = [
     createdAt: 1632133345,
   },
   {
-    id: 'joe-wavax-usdt.e',
+    id: 'joe-wavax-usdt.e-eol',
     name: 'USDT.e-AVAX LP',
     token: 'USDT.e-AVAX JLP',
     tokenDescription: 'Trader Joe',
@@ -4211,8 +4214,9 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'joe-wavax-usdt.e',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Trader Joe',
     assets: ['USDTe', 'AVAX'],
     risks: [
@@ -4543,7 +4547,7 @@ export const avalanchePools = [
     createdAt: 1630670273,
   },
   {
-    id: 'joe-qi-wavax',
+    id: 'joe-qi-wavax-eol',
     name: 'QI-AVAX LP',
     token: 'QI-AVAX JLP',
     tokenDescription: 'Trader Joe',
@@ -4558,8 +4562,9 @@ export const avalanchePools = [
     oracle: 'lps',
     oracleId: 'joe-qi-wavax',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Trader Joe',
     assets: ['aQI', 'AVAX'],
     risks: [

--- a/src/features/configure/vault/bsc_pools.js
+++ b/src/features/configure/vault/bsc_pools.js
@@ -1978,7 +1978,7 @@ export const bscPools = [
     createdAt: 1643275444,
   },
   {
-    id: 'cakev2-fuse-wbnb',
+    id: 'cakev2-fuse-wbnb-eol',
     name: 'FUSE-BNB LP',
     token: 'FUSE-BNB LP',
     tokenDescription: 'PancakeSwap',
@@ -1993,8 +1993,9 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'cakev2-fuse-wbnb',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'PancakeSwap',
     assets: ['FUSE', 'BNB'],
     risks: [
@@ -6297,7 +6298,7 @@ export const bscPools = [
     createdAt: 1627911930,
   },
   {
-    id: 'pera-pera-bnb',
+    id: 'pera-pera-bnb-eol',
     name: 'PERA-BNB LP',
     token: 'PERA-BNB LP',
     tokenDescription: 'PancakeSwap (Pera)',
@@ -6312,8 +6313,9 @@ export const bscPools = [
     oracle: 'lps',
     oracleId: 'pera-pera-bnb',
     oraclePrice: 0,
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Other',
     assets: ['PERA', 'BNB'],
     addLiquidityUrl:

--- a/src/features/configure/vault/fantom_pools.js
+++ b/src/features/configure/vault/fantom_pools.js
@@ -641,7 +641,7 @@ export const fantomPools = [
     oracle: 'lps',
     oracleId: 'beets-two-gods-one-pool',
     oraclePrice: 0,
-    depositsPaused: false,
+    depositsPaused: true,
     status: 'active',
     platform: 'Beethoven X',
     assets: ['DEUS', 'DEI'],

--- a/src/features/configure/vault/fuse_pools.js
+++ b/src/features/configure/vault/fuse_pools.js
@@ -467,7 +467,7 @@ export const fusePools = [
     createdAt: 1647505730,
   },
   {
-    id: 'voltagev2-wfuse-atust',
+    id: 'voltagev2-wfuse-atust-eol',
     name: 'atUST-FUSE LP',
     token: 'atUST-FUSE LP',
     tokenDescription: 'Voltage',
@@ -483,8 +483,9 @@ export const fusePools = [
     oracleId: 'voltagev2-wfuse-atust',
     oraclePrice: 0,
     withdrawalFee: '0%',
-    depositsPaused: false,
-    status: 'active',
+    depositsPaused: true,
+    status: 'eol',
+    retireReason: 'rewards',
     platform: 'Voltage',
     assets: ['UST', 'FUSE'],
     risks: [


### PR DESCRIPTION
EOL vaults due to rewards ending:
https://app.beefy.finance/#/vault/joe-wavax-usdt.e 
https://app.beefy.finance/#/vault/joe-qi-wavax 
https://app.beefy.finance/#/vault/joe-wavax-hec 
https://app.beefy.finance/#/vault/joe-dby-wavax
https://app.beefy.finance/#/vault/joe-tus-wavax 
https://app.beefy.finance/#/vault/pera-pera-bnb 
voltagev2-wfuse-atust
cakev2-fuse-wbnb

eol per weso, new vaults for the dual rewards farm due to aurora gas limitations
trisolaris-usdt-near 
trisolaris-usdc-near

Pause Deposits until strat upgrade is completed to compound just DEUS rewards (with no BEETS rewards):
beets-two-gods-one-pool


